### PR TITLE
fix: Add auth scheme

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8,6 +8,8 @@ servers:
 tags:
 - name: OpenAI
   description: The OpenAI REST API
+security:
+  - bearer: []
 paths:
   /engines:
     get:
@@ -3124,6 +3126,10 @@ components:
         - created_at
         - level
         - message
+  securitySchemes:
+    bearer:
+      type: http
+      scheme: bearer
 
 x-oaiMeta:
   groups:


### PR DESCRIPTION
This PR adds an authorization entry to the OpenAPI schema so that when the code is generated by an automatic generator tool such as openapi-generator, the logic for authorization is generated.

We have added a Bearer authorization field throughout.

resolve #8 