### PR TITLE
Remove incorrect `id` and `model` properties from `CreateEditResponse`

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2137,14 +2137,10 @@ components:
     CreateEditResponse:
       type: object
       properties:
-        id:
-          type: string
         object:
           type: string
         created:
           type: integer
-        model:
-          type: string
         choices:
           type: array
           items:
@@ -2190,10 +2186,8 @@ components:
             - completion_tokens
             - total_tokens
       required: 
-        - id
         - object
         - created
-        - model
         - choices
         - usage
 


### PR DESCRIPTION
The `id` and `model` properties are defined in the `CreateEditResponse` schema, but these properties are not returned by the `POST` `/edits` endpoint.

These two properties are also listed as required, which causes issues with [tools/libraries using this OpenAPI specification](https://github.com/tectalichq/public-openai-client-php/discussions/11).

Your [Postman Collection](https://www.postman.com/devrel/workspace/openai/documentation/13183464-90abb798-cb85-43cb-ba3a-ae7941e968da?entity=&branch=&version=) does not list these properties for the Create Edit response, it only lists `object`, `created`, `choices` and `usage`.

This pull request removes these `id` and `model` properties from the OpenAPI schema.

Example JSON response: from `https://api.openai.com/v1/edits` as of today:

```json
{
  "object": "edit",
  "created": 1675740853,
  "choices": [
    {
      "text": "Write a tagline for an ice cream shop. sweetest place.\n",
      "index": 0
    }
  ],
  "usage": {
    "prompt_tokens": 27,
    "completion_tokens": 35,
    "total_tokens": 62
  }
}
```

The [official API Reference](https://platform.openai.com/docs/api-reference/edits) does not mention either `id` or `model` in the response body:

```
{
  "object": "edit",
  "created": 1589478378,
  "choices": [
    {
      "text": "What day of the week is it?",
      "index": 0,
    }
  ],
  "usage": {
    "prompt_tokens": 25,
    "completion_tokens": 32,
    "total_tokens": 57
  }
}
```

So I believe these properties can be safely removed from the OpenAPI specification.

Fixes #7

Reported by @Netizine @janodev.