### PR TITLE
fix: ChatCompletionResponse finish_reason is nullable

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2427,6 +2427,7 @@ components:
                 $ref: '#/components/schemas/ChatCompletionResponseMessage'
               finish_reason:
                 type: string
+                nullable: true
         usage:
           type: object
           properties:


### PR DESCRIPTION
Here is the response I just got:
```
{
  "id": "chatcmpl-6pNqnABbg9IXfsR4aPuQmhF9vaJ7a",
  "object": "chat.completion",
  "created": 1677704429,
  "model": "gpt-3.5-turbo-0301",
  "usage": {
    "prompt_tokens": 1898,
    "completion_tokens": 1040,
    "total_tokens": 2938
  },
  "choices": [
    {
      "message": {
        "role": "assistant",
        "content": "..."
      },
      "finish_reason": null,
      "index": 0
    }
  ]
}
```