### PR TITLE
update CreateChatCompletionRequest.model

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2323,6 +2323,9 @@ components:
         model:
           description: ID of the model to use. Currently, only `gpt-3.5-turbo` and `gpt-3.5-turbo-0301` are supported.
           type: string
+          enum: ["gpt-4", "gpt-4-0314", "gpt-4-32k", "gpt-4-32k-0314", "gpt-3.5-turbo", "gpt-3.5-turbo-0301"]
+          nullable: false
+          example: "gpt-4"
         messages:
           description: The messages to generate chat completions for, in the [chat format](/docs/guides/chat/introduction).
           type: array


### PR DESCRIPTION
`CreateChatCompletionRequest` is the most critical API endpoint request. So it would be convenient for developer to easily use the best choice with ease of use. So I suggest using enum rather than free string. It's also easy to maintain as I assume the out-of-date models will be deprecated soon.

> /v1/chat/completions => gpt-4, gpt-4-0314, gpt-4-32k, gpt-4-32k-0314, gpt-3.5-turbo, gpt-3.5-turbo-0301