### PR TITLE
Removes an extra word in the Create Translation section summary

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -717,7 +717,7 @@ paths:
       operationId: createTranslation
       tags:
         - OpenAI
-      summary: Translates audio into into English.
+      summary: Translates audio into English.
       requestBody:
         required: true
         content:


### PR DESCRIPTION
This just fixes the summary of the Create Translation section from "Translates audio into into English." to "Translates audio into English."