### PR TITLE
Mark `POST /completions` `prompt` as a required param

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2244,6 +2244,7 @@ components:
             A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](/docs/guides/safety-best-practices/end-user-ids).
       required:
         - model
+        - prompt
     
     CreateCompletionResponse:
       type: object


### PR DESCRIPTION
Users almost always want to send this – they can always send null, empty string, or empty array if they really want an empty prompt.