### PR TITLE
make function_call optional

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2400,7 +2400,6 @@ components:
             - type: null
             - type: string
               enum: [none, auto]
-              nullable: true
             - type: object
               properties:
                 name:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2397,6 +2397,7 @@ components:
         function_call:
           description: Controls how the model responds to function calls. "none" means the model does not call a function, and responds to the end-user. "auto" means the model can pick between an end-user or calling a function.  Specifying a particular function via `{"name":\ "my_function"}` forces the model to call that function. "none" is the default when no functions are present. "auto" is the default if functions are present.
           oneOf:
+            - type: null
             - type: string
               enum: [none, auto]
             - type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2396,8 +2396,8 @@ components:
             $ref: '#/components/schemas/ChatCompletionFunctions'
         function_call:
           description: Controls how the model responds to function calls. "none" means the model does not call a function, and responds to the end-user. "auto" means the model can pick between an end-user or calling a function.  Specifying a particular function via `{"name":\ "my_function"}` forces the model to call that function. "none" is the default when no functions are present. "auto" is the default if functions are present.
+          nullable: true
           oneOf:
-            - type: null
             - type: string
               enum: [none, auto]
             - type: object


### PR DESCRIPTION
The new parameter `function_call` can be one of three cases:
1. an enum of value none or auto
2. an object with a name
3. null (since it can be omitted)

Without this fix, api generators like `NSwag` will mark this field as non nullable, causing resulting in API error when sending `function_call: none` without any `function` being defined, for example.