### PR TITLE
Mark all properties in "choices" as required

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2261,6 +2261,11 @@ components:
           type: array
           items:
             type: object
+            required:
+              - text
+              - index
+              - logprobs
+              - finish_reason
             properties:
               text:
                 type: string


### PR DESCRIPTION
I'm not sure whether this is actually the case (please decline the PR if not!) but I would expect all keys of this object to be present in all responses (though of course logprobs is marked as sometimes having a `null` value).

Making this change would enable nicer types, eg, `response.choices[0].text.length` rather than `response.choices[0].text?.length`