### PR TITLE
Mark function.parameters as required

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1919,8 +1919,9 @@ components:
           description: The description of what the function does.
         parameters:
           $ref: '#/components/schemas/ChatCompletionFunctionParameters'
-      required: 
+      required:
         - name
+        - parameters
 
     ChatCompletionResponseMessage:
       type: object


### PR DESCRIPTION
In https://github.com/openai/openai-node/issues/181#issuecomment-1611712836, a user claimed that a function without `parameters` specified will not be called, but the same function with `parameters: { 'type': 'object', properties: {} }` is called. This leads me to believe that the user should always pass `parameters`, even if they must be an empty object.

A better approach to marking this required might be to make this the default on the server side, so that users do not need to pass this object for functions which accept no parameters. However, in case that'll take some time to get to, I wanted to put up this PR for now to improve the DX in the meantime.