### PR TITLE
Add `response_format` enum to transcriptions

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2809,6 +2809,12 @@ components:
           description: |
             The format of the transcript output, in one of these options: json, text, srt, verbose_json, or vtt.
           type: string
+          enum:
+            - json
+            - text
+            - srt
+            - verbose_json
+            - vtt
           default: json
         temperature:
           description: |


### PR DESCRIPTION
I noticed this when looking into https://github.com/openai/openai-node/issues/155

I simply copied the options from the documentation; I'm not certain the list is exhaustive.