### PR TITLE
Fix code sample for image edits

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -382,8 +382,8 @@ paths:
             const openai = new OpenAIApi(configuration);
             const response = await openai.createImageEdit(
               fs.createReadStream("otter.png"),
-              fs.createReadStream("mask.png"),
               "A cute baby sea otter wearing a beret",
+              fs.createReadStream("mask.png"),
               2,
               "1024x1024"
             );


### PR DESCRIPTION
See https://github.com/openai/openai-node/issues/95; the `prompt` must be specified before the `mask`, unfortunately.

This should be obsolete soon, but may as well fix.