### PR TITLE
Define the maximum number of documents to embed in a single request

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2711,6 +2711,8 @@ components:
               default: ''
               example: "This is a test."
             - type: array
+              minItems: 1
+              maxItems: 2048
               items:
                 type: string
                 default: ''
@@ -2722,6 +2724,7 @@ components:
               example: "[1212, 318, 257, 1332, 13]"
             - type: array
               minItems: 1
+              maxItems: 2048
               items:
                 type: array
                 minItems: 1


### PR DESCRIPTION
I couldn't find confirmation for the maximum  number of documents to embed in a single request in any of the official sources. This is the only [source](https://js.langchain.com/docs/api/embeddings_openai/interfaces/OpenAIEmbeddingsParams#:~:text=%E2%80%8B,-batchSize%3A%20number&text=The%20maximum%20number%20of%20documents,to%20a%20maximum%20of%202048.), but empirically this seems to hold. 
Please correct me if I'm wrong about it.