### PR TITLE
Update functions limit to 128

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2253,6 +2253,7 @@ components:
           description: A list of functions the model may generate JSON inputs for.
           type: array
           minItems: 1
+          maxItems: 128
           items:
             $ref: "#/components/schemas/ChatCompletionFunctions"
         function_call:


### PR DESCRIPTION
Sets the `maxItems` on functions to 128.