### PR TITLE
FineTuningJob `trained_tokens` property should be nullable

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3848,6 +3848,7 @@ components:
             $ref: "#/components/schemas/OpenAIFile"
         trained_tokens:
           type: integer
+          nullable: true
           description: The total number of billable tokens processed by this fine-tuning job.
       required:
         - id


### PR DESCRIPTION
After submitting a new fine-tuning job, the `trained_tokens` property in the response is returned as `null`.

It continues to be `null` until the `status` changes from `running` to `succeeded`.

After it has `succeeded`, then `trained_tokens` returns an integer.

Example response when `running`:

```json
{
  "created_at" : 1693894540,
  "fine_tuned_model" : null,
  "finished_at" : null,
  "hyperparameters" : {
    "n_epochs" : 10
  },
  "id" : "ftjob-123",
  "model" : "gpt-3.5-turbo-0613",
  "object" : "fine_tuning.job",
  "organization_id" : "org-123",
  "result_files" : [

  ],
  "status" : "running",
  "trained_tokens" : null,
  "training_file" : "file-123",
  "validation_file" : null
}
```

Example when `succeeded`:

```json
{
  "created_at" : 1693894540,
  "fine_tuned_model" : "ft:gpt-3.5-turbo-0613:org::123",
  "finished_at" : 1693895153,
  "hyperparameters" : {
    "n_epochs" : 10
  },
  "id" : "ftjob-123",
  "model" : "gpt-3.5-turbo-0613",
  "object" : "fine_tuning.job",
  "organization_id" : "org-123",
  "result_files" : [
    "file-456"
  ],
  "status" : "succeeded",
  "trained_tokens" : 3700,
  "training_file" : "file-123",
  "validation_file" : null
}
```

This change ensures that generated clients can correctly parse the response without expecting `trained_tokens` to *always* be an integer.

Other fields that behave in the same way are `fine_tuned_model` and `finished_at`, which are also `null` while the fine tuning job is running. One of those is already nullable, and the other is not required so they do not cause a problem.