### PR TITLE
Make CreateTranscriptionResponse a oneOf with string and verbose json

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1255,7 +1255,7 @@ paths:
 
               async function main() {
                 const fineTune = await openai.fineTuning.jobs.retrieve("ft-AF1WoRqd3aJAHsqc9NY7iL8F");
-                
+
                 console.log(fineTune);
               }
 
@@ -3620,14 +3620,78 @@ components:
         - file
         - model
 
-    # Note: This does not currently support the non-default response format types.
     CreateTranscriptionResponse:
+      description: |
+        The shape of this response depends on the `response_format` sent in the request;
+        with `'text'`, `'srt'`, or `'vtt'`, this is a string.
+      oneOf:
+        - type: string
+        - $ref: "#/components/schemas/CreateTranscriptionDefaultResponse"
+        - $ref: "#/components/schemas/CreateTranscriptionVerboseResponse"
+
+    CreateTranscriptionDefaultResponse:
       type: object
       properties:
         text:
           type: string
       required:
         - text
+
+    CreateTranscriptionVerboseResponse:
+      type: object
+      properties:
+        task:
+          type: string
+        language:
+          type: string
+        duration:
+          type: number
+        text:
+          type: string
+        segments:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: number
+              seek:
+                type: number
+              start:
+                type: number
+              end:
+                type: number
+              text:
+                type: string
+              tokens:
+                type: array
+                items:
+                  type: number
+              temperature:
+                type: number
+              avg_logprob:
+                type: number
+              compression_ratio:
+                type: number
+              no_speech_prob:
+                type: number
+            required:
+              - id
+              - seek
+              - start
+              - end
+              - text
+              - tokens
+              - temperature
+              - avg_logprob
+              - compression_ratio
+              - no_speech_prob
+      required:
+        - task
+        - language
+        - duration
+        - text
+        - segments
 
     CreateTranslationRequest:
       type: object
@@ -3844,7 +3908,7 @@ components:
           description: The file ID used for validation. You can retrieve the validation results with the [Files API](/docs/api-reference/files/retrieve-contents).
         result_files:
           type: array
-          description: The compiled results file ID(s) for the fine-tuning job. You can retrieve the results with the [Files API](/docs/api-reference/files/retrieve-contents).  
+          description: The compiled results file ID(s) for the fine-tuning job. You can retrieve the results with the [Files API](/docs/api-reference/files/retrieve-contents).
           items:
             type: string
             example: file-abc123


### PR DESCRIPTION
This would resolve https://github.com/openai/openai-node/pull/221. 

I don't actually recommend merging this until our SDK codegen can generate overloads that correctly map the `response_format` request param to the appropriate response schema (OpenAPI does not have a feature for this, so we'll need to invent an `x-stainless` workaround of some kind). 

If we were to merge this in the short term, all Node users who are creating transcriptions with the Node SDK with the default response type would get a type error on upgrade, and be forced to manually specify which union member their response is, which can be confusing. I'd rather we not regress the default integration path for now.

That said, this is technically more accurate, and it's all OpenAPI can support, so it'd be okay to merge it too if you like. 

At the minimum, the existence of this PR maybe helpful to other developers trying to understand what the `verbose_json` format is.