### PR TITLE
fix: add content_filter and function_call to finish_reason

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2509,7 +2509,7 @@ components:
                 description: &completion_finish_reason_description |
                   The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence,
                   or `length` if the maximum number of tokens specified in the request was reached.
-                enum: ["stop", "length"]
+                enum: ["stop", "length", "content_filter", "function_call"]
         usage:
           $ref: "#/components/schemas/CompletionUsage"
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2508,7 +2508,10 @@ components:
                 type: string
                 description: &completion_finish_reason_description |
                   The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence,
-                  or `length` if the maximum number of tokens specified in the request was reached.
+                  `length` if the maximum number of tokens specified in the request was reached,
+                  `content_filter` if content was omitted due to a flag from our content filters,
+                  or `function_call` if the model decided to call a function.
+
                 enum: ["stop", "length", "content_filter", "function_call"]
         usage:
           $ref: "#/components/schemas/CompletionUsage"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2509,10 +2509,8 @@ components:
                 description: &completion_finish_reason_description |
                   The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence,
                   `length` if the maximum number of tokens specified in the request was reached,
-                  `content_filter` if content was omitted due to a flag from our content filters,
-                  or `function_call` if the model decided to call a function.
-
-                enum: ["stop", "length", "content_filter", "function_call"]
+                  or `content_filter` if content was omitted due to a flag from our content filters.
+                enum: ["stop", "length", "content_filter"]
         usage:
           $ref: "#/components/schemas/CompletionUsage"
       required:
@@ -2816,8 +2814,10 @@ components:
                 type: string
                 description: &chat_completion_finish_reason_description |
                   The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence,
-                  `length` if the maximum number of tokens specified in the request was reached, or `function_call` if the model called a function.
-                enum: ["stop", "length", "function_call"]
+                  `length` if the maximum number of tokens specified in the request was reached,
+                  `content_filter` if content was omitted due to a flag from our content filters,
+                  or `function_call` if the model called a function.
+                enum: ["stop", "length", "function_call", "content_filter"]
         usage:
           $ref: "#/components/schemas/CompletionUsage"
       required:


### PR DESCRIPTION
Would address https://github.com/openai/openai-node/issues/320

I have not verified whether this or https://platform.openai.com/docs/guides/gpt/chat-completions-api is more accurate on this subject.