### PR TITLE
Remove logprobs required in Completion Response

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2476,7 +2476,6 @@ components:
             required:
               - text
               - index
-              - logprobs
               - finish_reason
             properties:
               text:


### PR DESCRIPTION
Should `logprobs` be required?  I'm getting responses where it's missing (not just null), causing Swift openapi generator to throw runtime errors. This pr fixes that.