### PR TITLE
Make finish_reason nullable in CreateCompletionResponse

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2667,6 +2667,7 @@ components:
             properties:
               finish_reason:
                 type: string
+                nullable: true
                 description: &completion_finish_reason_description |
                   The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence,
                   `length` if the maximum number of tokens specified in the request was reached,


### PR DESCRIPTION
Currently, the [completion object](https://platform.openai.com/docs/api-reference/completions/object) is used for both streamed and non-streamed modes. However, there's a subtle difference between the two modes: when using streaming `finish_reason` is `null` until the last emission.

Example:
```sh
curl https://api.openai.com/v1/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer {api_key}" \
  -d '{
    "model": "gpt-3.5-turbo-instruct",
    "prompt": "Say this is a test",
    "temperature": 0,
    "stream": true
  }'
```
```http
data: {"id":"cmpl-8DRxiREy3SiZNrgxq9DScOdNBxwRJ","object":"text_completion","created":1698216442,"choices":[{"text":"\n\n","index":0,"logprobs":null,"finish_reason":null}],"model":"gpt-3.5-turbo-instruct"}

data: {"id":"cmpl-8DRxiREy3SiZNrgxq9DScOdNBxwRJ","object":"text_completion","created":1698216442,"choices":[{"text":"This","index":0,"logprobs":null,"finish_reason":null}],"model":"gpt-3.5-turbo-instruct"}

data: {"id":"cmpl-8DRxiREy3SiZNrgxq9DScOdNBxwRJ","object":"text_completion","created":1698216442,"choices":[{"text":" is","index":0,"logprobs":null,"finish_reason":null}],"model":"gpt-3.5-turbo-instruct"}

data: {"id":"cmpl-8DRxiREy3SiZNrgxq9DScOdNBxwRJ","object":"text_completion","created":1698216442,"choices":[{"text":" a","index":0,"logprobs":null,"finish_reason":null}],"model":"gpt-3.5-turbo-instruct"}

data: {"id":"cmpl-8DRxiREy3SiZNrgxq9DScOdNBxwRJ","object":"text_completion","created":1698216442,"choices":[{"text":" test","index":0,"logprobs":null,"finish_reason":null}],"model":"gpt-3.5-turbo-instruct"}

data: {"id":"cmpl-8DRxiREy3SiZNrgxq9DScOdNBxwRJ","object":"text_completion","created":1698216442,"choices":[{"text":".","index":0,"logprobs":null,"finish_reason":null}],"model":"gpt-3.5-turbo-instruct"}

data: {"id":"cmpl-8DRxiREy3SiZNrgxq9DScOdNBxwRJ","object":"text_completion","created":1698216442,"choices":[{"text":"","index":0,"logprobs":null,"finish_reason":"stop"}],"model":"gpt-3.5-turbo-instruct"}

data: [DONE]
```

The current spec does not allow the `finish_reason` field to be `null`, which creates issues when using streaming in a client generated from the spec.

Assuming that keeping the same schema for both modes is the preferred option, this PR makes the `finish_reason` field nullable.

An alternative would be to split the `CreateCompletionResponse` schema into `CreateCompletionResponse` and `CreateCompletionStreamResponse` like it is done in the `ChatCompletionResponse` definition.