### PR TITLE
Don't mark `post /threads` request body as required

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3036,7 +3036,6 @@ paths:
         - Assistants
       summary: Create a thread.
       requestBody:
-        required: true
         content:
           application/json:
             schema:


### PR DESCRIPTION
The docs imply this is optional: https://platform.openai.com/docs/assistants/overview/step-2-create-a-thread

Addresses https://github.com/openai/openai-node/issues/448