### PR TITLE
fix type for image_url

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5544,19 +5544,23 @@ components:
           enum: ["image_url"]
           description: The type of the content part.
         image_url:
-          type: object
-          properties:
-            url:
-              type: string
-              description: Either a URL of the image or the base64 encoded image data.
+          oneOf:
+            - type: object
+              properties:
+                url:
+                  type: string
+                  description: Either a URL of the image or the base64 encoded image data.
+                  format: uri
+                detail:
+                  type: string
+                  description: Specifies the detail level of the image.
+                  enum: ["auto", "low", "high"]
+                  default: "auto"
+              required:
+                - data
+            - type: string
+              description: A URL of the image.
               format: uri
-            detail:
-              type: string
-              description: Specifies the detail level of the image.
-              enum: ["auto", "low", "high"]
-              default: "auto"
-          required:
-            - data
       required:
         - type
         - image_url

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5557,7 +5557,7 @@ components:
                   enum: ["auto", "low", "high"]
                   default: "auto"
               required:
-                - data
+                - url
             - type: string
               description: A URL of the image.
               format: uri


### PR DESCRIPTION
Related to https://github.com/openai/openai-node/pull/451

According to the new document
https://platform.openai.com/docs/guides/vision
the `image_url` accepts both string url and detailed struct.