### PR TITLE
Fix CreateEmbeddingResponse object type

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7123,8 +7123,8 @@ components:
           description: The name of the model used to generate the embedding.
         object:
           type: string
-          description: The object type, which is always "embedding".
-          enum: [embedding]
+          description: The object type, which is always "list".
+          enum: [list]
         usage:
           type: object
           description: The usage information for the request.


### PR DESCRIPTION
The current object is set `embedding` but the API returns `list` instead.

Example:
```sh
curl https://api.openai.com/v1/embeddings \
  -H "Authorization: Bearer $OPENAI_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "input": "The food was delicious and the waiter...",
    "model": "text-embedding-ada-002",
    "encoding_format": "float"
  }'
```
Response:
```json
{
  "object": "list",
  "data": [
    {
      "object": "embedding",
      "index": 0,
      "embedding": [ 0.0022579778, ...]
    }
  ],
  "model": "text-embedding-ada-002-v2",
  "usage": {
    "prompt_tokens": 8,
    "total_tokens": 8
  }
}
```

cc @schnerd