### PR TITLE
Fix accidental inclusion of thread_id in required

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8187,7 +8187,6 @@ components:
           x-oaiTypeLabel: map
           nullable: true
       required:
-        - thread_id
         - assistant_id
     ListRunsResponse:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8302,7 +8302,6 @@ components:
           x-oaiTypeLabel: map
           nullable: true
       required:
-        - thread_id
         - assistant_id
 
     ThreadObject:


### PR DESCRIPTION
This param is a required path param, not a body param.