### PR TITLE
Fixed Tag Typo on ModifyAssistant

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2906,7 +2906,7 @@ paths:
     post:
       operationId: modifyAssistant
       tags:
-        - Assistant
+        - Assistants
       summary: Modifies an assistant.
       parameters:
         - in: path


### PR DESCRIPTION
The tag of modifyAssistant was missing it's `s`.

According to lines 15-17, the Assistants tag should have an `s`. It was missing.

```yaml
tags:
  - name: Assistants
    description: Build Assistants that can call models and use tools.
```

