### PR TITLE
Mark tool_choice.{type,function} as required

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5823,6 +5823,9 @@ components:
               description: The name of the function to call.
           required:
             - name
+      required:
+        - type
+        - function
 
     ChatCompletionMessageToolCalls:
       type: array


### PR DESCRIPTION
Fixes https://github.com/openai/openai-node/issues/521

Current API behavior is to throw if `type: function` is not provided, my assumption is that `function` is also required.

cc @athyuttamre