### PR TITLE
Constrain `response_format` to documented accepted values

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7324,6 +7324,12 @@ components:
           description: |
             The format of the transcript output, in one of these options: `json`, `text`, `srt`, `verbose_json`, or `vtt`.
           type: string
+          enum:
+            - json
+            - text
+            - srt
+            - verbose_json
+            - vtt
           default: json
         temperature:
           description: |


### PR DESCRIPTION
Essentially, it takes the same options as `transcribe`, as done in #58.

Ref in docs:
https://platform.openai.com/docs/api-reference/audio/createTranslation#audio-createtranslation-response_format

Ref in transcriptions:
https://github.com/openai/openai-openapi/blob/23a4b18b65bb7b002894bae1084d99134b2897e3/openapi.yaml#L7271-L7281