### PR TITLE
Make RunObject.expires_at nullable

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8250,6 +8250,7 @@ components:
         expires_at:
           description: The Unix timestamp (in seconds) for when the run will expire.
           type: integer
+          nullable: true
         started_at:
           description: The Unix timestamp (in seconds) for when the run was started.
           type: integer


### PR DESCRIPTION
`RunObject.expires_at` can be null (e.g. when the run is `completed`).

Example:
```json
{
  "id": "run_soD0ciq9WNNZ2FL6zDlcur7b",
  "object": "thread.run",
  "created_at": 1703355405,
  "assistant_id": "asst_uzsXn9NW5FURQq4qU8Byqr0T",
  "thread_id": "thread_rhvsVlbAf00zQ9DgMTfZE7BS",
  "status": "completed",
  "started_at": 1703355405,
  "expires_at": null,
  "cancelled_at": null,
  "failed_at": null,
  "completed_at": 1703355420,
  "last_error": null,
  "model": "gpt-4",
  "instructions": "Please address the user as Jane Doe. The user has a premium account.",
  "tools": [
    {
      "type": "code_interpreter"
    }
  ],
  "file_ids": [],
  "metadata": {}
}
```

This PR makes `RunObject.expires_at` nullable.

cc @schnerd