### PR TITLE
Add `has_more` property to ListFineTuningJobEventsResponse

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7697,12 +7697,15 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/FineTuningJobEvent"
+        has_more:
+          type: boolean
         object:
           type: string
           enum: [list]
       required:
         - object
         - data
+        - has_more
 
     ListFineTuningJobCheckpointsResponse:
       type: object


### PR DESCRIPTION
I noticed this gap and decided to raise a PR. It doesn't align with https://platform.openai.com/docs/api-reference/fine-tuning/list-events