### PR TITLE
Remove required `thread_id`  from CreateRunRequest and CreateThreadAndRunRequest

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9234,7 +9234,6 @@ components:
           $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
           nullable: true
       required:
-        - thread_id
         - assistant_id
     ListRunsResponse:
       type: object
@@ -9416,7 +9415,6 @@ components:
           $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
           nullable: true
       required:
-        - thread_id
         - assistant_id
 
     ThreadObject:


### PR DESCRIPTION
`thread_id` is not a required field (actually not even one of the fields) in `CreateRunRequest` and `CreateThreadAndRunRequest` objects