### PR TITLE
thread_id is not in request body

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7720,7 +7720,6 @@ components:
           x-oaiTypeLabel: map
           nullable: true
       required:
-        - thread_id
         - assistant_id
     ListRunsResponse:
       type: object


### PR DESCRIPTION
it is present in the URL, which is where it is already required.