### PR TITLE
Remove minItems for CreateMessageRequest file_ids

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8063,7 +8063,6 @@ components:
           description: A list of [File](/docs/api-reference/files) IDs that the message should use. There can be a maximum of 10 files attached to a message. Useful for tools like `retrieval` and `code_interpreter` that can access and use files.
           default: []
           type: array
-          minItems: 1
           maxItems: 10
           items:
             type: string


### PR DESCRIPTION
The file_ids field here is optional, so including minItems doesn't make sense.