### PR TITLE
Mark `RunObject`'s `expires_at` property as nullable

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7848,6 +7848,7 @@ components:
         expires_at:
           description: The Unix timestamp (in seconds) for when the run will expire.
           type: integer
+          nullable: true
         started_at:
           description: The Unix timestamp (in seconds) for when the run was started.
           type: integer


### PR DESCRIPTION
In practice, when a run reaches the "completed" state, its `expires_at` property becomes `null`. To reflect this behavior, this change simply marks the `expires_at` property of the `RunObject` definition as `nullable: true`.