### PR TITLE
remove unspecified but required thread_id from CreateRunRequest

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8639,7 +8639,6 @@ components:
           description: |
             If `true`, returns a stream of events that happen during the Run as server-sent events, terminating when the Run enters a terminal state with a `data: [DONE]` message.
       required:
-        - thread_id
         - assistant_id
     ListRunsResponse:
       type: object


### PR DESCRIPTION
I think this isn't meant to be required, since there's no specification of it in the properties, is that the right understanding?