### PR TITLE
 Bump actions/checkout to v4 in GitHub Actions workflows

### DIFF
--- a/.github/workflows/upload-to-stainless.yml
+++ b/.github/workflows/upload-to-stainless.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stainless — Upload OpenAPI specification
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: stainless-api/upload-openapi-spec-action@v0.2.1
         with:
           stainless_api_key: ${{ secrets.STAINLESS_API_KEY }}

--- a/.github/workflows/validate-openapi.yml
+++ b/.github/workflows/validate-openapi.yml
@@ -19,7 +19,7 @@ jobs:
           - 80:8080
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Validate OpenAPI definition
         uses: char0n/swagger-editor-validate@v1
         with:


### PR DESCRIPTION
Bumping the version of actions/checkout used in these workflows, reference https://github.com/actions/checkout?tab=readme-ov-file#checkout-v4