### PR TITLE
Make Vector Store name nullable

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12074,6 +12074,7 @@ components:
         name:
           description: The name of the vector store.
           type: string
+          nullable: true
         usage_bytes:
           description: The total number of bytes used by the files in the vector store.
           type: integer


### PR DESCRIPTION
When creating a vector store, the [name is not required](https://platform.openai.com/docs/api-reference/vector-stores/create). However, the `VectorStoreObject` does not support a `null` name.

The server does support nullable names. If you don't provide a name when creating the vector store, when you retrieve the vector store, the name is sent as `null`.

This PR make the `name` field nullable.