### PR TITLE
Update model property in ModifyAssistantRequest

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -11241,7 +11241,7 @@ components:
                 - object
                 - created_at
                 - thread_id
-                - status
+                # - status
                 - incomplete_details
                 - completed_at
                 - incomplete_at

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10079,8 +10079,34 @@ components:
             properties:
                 model:
                     description: *model_description
+                    example: "gpt-4-turbo"
                     anyOf:
                         - type: string
+                        - type: string
+                          enum:
+                              [
+                                  "gpt-4o",
+                                  "gpt-4o-2024-05-13",
+                                  "gpt-4-turbo",
+                                  "gpt-4-turbo-2024-04-09",
+                                  "gpt-4-0125-preview",
+                                  "gpt-4-turbo-preview",
+                                  "gpt-4-1106-preview",
+                                  "gpt-4-vision-preview",
+                                  "gpt-4",
+                                  "gpt-4-0314",
+                                  "gpt-4-0613",
+                                  "gpt-4-32k",
+                                  "gpt-4-32k-0314",
+                                  "gpt-4-32k-0613",
+                                  "gpt-3.5-turbo",
+                                  "gpt-3.5-turbo-16k",
+                                  "gpt-3.5-turbo-0613",
+                                  "gpt-3.5-turbo-1106",
+                                  "gpt-3.5-turbo-0125",
+                                  "gpt-3.5-turbo-16k-0613",
+                              ]
+                    x-oaiTypeLabel: string
                 name:
                     description: *assistant_name_param_description
                     type: string


### PR DESCRIPTION
The `model` property in `ModifyAssistantRequest` is a string with no enum values. That's an inconsistency in the API. So I just copied over the `model` property in `CreateAssistantRequest`. The best way I suppose is to add a `Model` or `LLM` schema in the components section and then reference it where needed.