### PR TITLE
Update summary field name to description in info objects

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -43,7 +43,7 @@ paths:
             operationId: createChatCompletion
             tags:
                 - Chat
-            summary: Creates a model response for the given chat conversation.
+            description: Creates a model response for the given chat conversation.
             requestBody:
                 required: true
                 content:
@@ -57,6 +57,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/CreateChatCompletionResponse"
+
+            summary: Create chat completion
 
             x-oaiMeta:
                 name: Create chat completion
@@ -680,7 +682,7 @@ paths:
             operationId: createCompletion
             tags:
                 - Completions
-            summary: Creates a completion for the provided prompt and parameters.
+            description: Creates a completion for the provided prompt and parameters.
             requestBody:
                 required: true
                 content:
@@ -694,6 +696,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/CreateCompletionResponse"
+            summary: Create completion
+
             x-oaiMeta:
                 name: Create completion
                 group: completions
@@ -824,7 +828,7 @@ paths:
             operationId: createImage
             tags:
                 - Images
-            summary: Creates an image given a prompt.
+            description: Creates an image given a prompt.
             requestBody:
                 required: true
                 content:
@@ -838,6 +842,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ImagesResponse"
+            summary: Create image
+
             x-oaiMeta:
                 name: Create image
                 group: images
@@ -892,7 +898,7 @@ paths:
             operationId: createImageEdit
             tags:
                 - Images
-            summary: Creates an edited or extended image given an original image and a prompt.
+            description: Creates an edited or extended image given an original image and a prompt.
             requestBody:
                 required: true
                 content:
@@ -906,6 +912,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ImagesResponse"
+            summary: Create image edit
+
             x-oaiMeta:
                 name: Create image edit
                 group: images
@@ -964,7 +972,7 @@ paths:
             operationId: createImageVariation
             tags:
                 - Images
-            summary: Creates a variation of a given image.
+            description: Creates a variation of a given image.
             requestBody:
                 required: true
                 content:
@@ -978,6 +986,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ImagesResponse"
+            summary: Create image variation
+
             x-oaiMeta:
                 name: Create image variation
                 group: images
@@ -1031,7 +1041,7 @@ paths:
             operationId: createEmbedding
             tags:
                 - Embeddings
-            summary: Creates an embedding vector representing the input text.
+            description: Creates an embedding vector representing the input text.
             requestBody:
                 required: true
                 content:
@@ -1045,6 +1055,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/CreateEmbeddingResponse"
+            summary: Create embeddings
+
             x-oaiMeta:
                 name: Create embeddings
                 group: embeddings
@@ -1112,7 +1124,7 @@ paths:
             operationId: createSpeech
             tags:
                 - Audio
-            summary: Generates audio from the input text.
+            description: Generates audio from the input text.
             requestBody:
                 required: true
                 content:
@@ -1132,6 +1144,8 @@ paths:
                             schema:
                                 type: string
                                 format: binary
+            summary: Create speech
+
             x-oaiMeta:
                 name: Create speech
                 group: audio
@@ -1184,7 +1198,7 @@ paths:
             operationId: createTranscription
             tags:
                 - Audio
-            summary: Transcribes audio into the input language.
+            description: Transcribes audio into the input language.
             requestBody:
                 required: true
                 content:
@@ -1200,6 +1214,8 @@ paths:
                                 oneOf:
                                     - $ref: "#/components/schemas/CreateTranscriptionResponseJson"
                                     - $ref: "#/components/schemas/CreateTranscriptionResponseVerboseJson"
+            summary: Create transcription
+
             x-oaiMeta:
                 name: Create transcription
                 group: audio
@@ -1370,7 +1386,7 @@ paths:
             operationId: createTranslation
             tags:
                 - Audio
-            summary: Translates audio into English.
+            description: Translates audio into English.
             requestBody:
                 required: true
                 content:
@@ -1386,6 +1402,8 @@ paths:
                                 oneOf:
                                     - $ref: "#/components/schemas/CreateTranslationResponseJson"
                                     - $ref: "#/components/schemas/CreateTranslationResponseVerboseJson"
+            summary: Create translation
+
             x-oaiMeta:
                 name: Create translation
                 group: audio
@@ -1432,7 +1450,7 @@ paths:
             operationId: listFiles
             tags:
                 - Files
-            summary: Returns a list of files that belong to the user's organization.
+            description: Returns a list of files that belong to the user's organization.
             parameters:
                 - in: query
                   name: purpose
@@ -1447,6 +1465,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ListFilesResponse"
+            summary: List files
+
             x-oaiMeta:
                 name: List files
                 group: files
@@ -1501,7 +1521,7 @@ paths:
             operationId: createFile
             tags:
                 - Files
-            summary: |
+            description: |
                 Upload a file that can be used across various endpoints. Individual files can be up to 512 MB, and the size of all files uploaded by one organization can be up to 100 GB.
 
                 The Assistants API supports files up to 2 million tokens and of specific file types. See the [Assistants Tools guide](/docs/assistants/tools) for details.
@@ -1524,6 +1544,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/OpenAIFile"
+            summary: Upload file
+
             x-oaiMeta:
                 name: Upload file
                 group: files
@@ -1573,7 +1595,7 @@ paths:
             operationId: deleteFile
             tags:
                 - Files
-            summary: Delete a file.
+            description: Delete a file.
             parameters:
                 - in: path
                   name: file_id
@@ -1588,6 +1610,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/DeleteFileResponse"
+            summary: Delete file
+
             x-oaiMeta:
                 name: Delete file
                 group: files
@@ -1625,7 +1649,7 @@ paths:
             operationId: retrieveFile
             tags:
                 - Files
-            summary: Returns information about a specific file.
+            description: Returns information about a specific file.
             parameters:
                 - in: path
                   name: file_id
@@ -1640,6 +1664,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/OpenAIFile"
+            summary: Retrieve file
+
             x-oaiMeta:
                 name: Retrieve file
                 group: files
@@ -1680,7 +1706,7 @@ paths:
             operationId: downloadFile
             tags:
                 - Files
-            summary: Returns the contents of the specified file.
+            description: Returns the contents of the specified file.
             parameters:
                 - in: path
                   name: file_id
@@ -1695,6 +1721,8 @@ paths:
                         application/json:
                             schema:
                                 type: string
+            summary: Retrieve file content
+
             x-oaiMeta:
                 name: Retrieve file content
                 group: files
@@ -1727,7 +1755,7 @@ paths:
             operationId: createFineTuningJob
             tags:
                 - Fine-tuning
-            summary: |
+            description: |
                 Creates a fine-tuning job which begins the process of creating a new model from a given dataset.
 
                 Response includes details of the enqueued job including job status and the name of the fine-tuned models once complete.
@@ -1746,6 +1774,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/FineTuningJob"
+            summary: Create fine-tuning job
+
             x-oaiMeta:
                 name: Create fine-tuning job
                 group: fine-tuning
@@ -1948,7 +1978,7 @@ paths:
             operationId: listPaginatedFineTuningJobs
             tags:
                 - Fine-tuning
-            summary: |
+            description: |
                 List your organization's fine-tuning jobs
             parameters:
                 - name: after
@@ -1971,6 +2001,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ListPaginatedFineTuningJobsResponse"
+            summary: List fine-tuning jobs
+
             x-oaiMeta:
                 name: List fine-tuning jobs
                 group: fine-tuning
@@ -2021,7 +2053,7 @@ paths:
             operationId: retrieveFineTuningJob
             tags:
                 - Fine-tuning
-            summary: |
+            description: |
                 Get info about a fine-tuning job.
 
                 [Learn more about fine-tuning](/docs/guides/fine-tuning)
@@ -2041,6 +2073,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/FineTuningJob"
+            summary: Retrieve fine-tuning job
+
             x-oaiMeta:
                 name: Retrieve fine-tuning job
                 group: fine-tuning
@@ -2097,7 +2131,7 @@ paths:
             operationId: listFineTuningEvents
             tags:
                 - Fine-tuning
-            summary: |
+            description: |
                 Get status updates for a fine-tuning job.
             parameters:
                 - in: path
@@ -2128,6 +2162,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ListFineTuningJobEventsResponse"
+            summary: List fine-tuning events
+
             x-oaiMeta:
                 name: List fine-tuning events
                 group: fine-tuning
@@ -2189,7 +2225,7 @@ paths:
             operationId: cancelFineTuningJob
             tags:
                 - Fine-tuning
-            summary: |
+            description: |
                 Immediately cancel a fine-tune job.
             parameters:
                 - in: path
@@ -2207,6 +2243,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/FineTuningJob"
+            summary: Cancel fine-tuning
+
             x-oaiMeta:
                 name: Cancel fine-tuning
                 group: fine-tuning
@@ -2253,7 +2291,7 @@ paths:
             operationId: listFineTuningJobCheckpoints
             tags:
                 - Fine-tuning
-            summary: |
+            description: |
                 List checkpoints for a fine-tuning job.
             parameters:
                 - in: path
@@ -2284,6 +2322,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ListFineTuningJobCheckpointsResponse"
+            summary: List fine-tuning checkpoints
+
             x-oaiMeta:
                 name: List fine-tuning checkpoints
                 group: fine-tuning
@@ -2332,7 +2372,7 @@ paths:
             operationId: listModels
             tags:
                 - Models
-            summary: Lists the currently available models, and provides basic information about each one such as the owner and availability.
+            description: Lists the currently available models, and provides basic information about each one such as the owner and availability.
             responses:
                 "200":
                     description: OK
@@ -2340,6 +2380,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ListModelsResponse"
+            summary: List models
+
             x-oaiMeta:
                 name: List models
                 group: models
@@ -2397,7 +2439,7 @@ paths:
             operationId: retrieveModel
             tags:
                 - Models
-            summary: Retrieves a model instance, providing basic information about the model such as the owner and permissioning.
+            description: Retrieves a model instance, providing basic information about the model such as the owner and permissioning.
             parameters:
                 - in: path
                   name: model
@@ -2414,6 +2456,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/Model"
+            summary: Retrieve model
+
             x-oaiMeta:
                 name: Retrieve model
                 group: models
@@ -2451,7 +2495,7 @@ paths:
             operationId: deleteModel
             tags:
                 - Models
-            summary: Delete a fine-tuned model. You must have the Owner role in your organization to delete a model.
+            description: Delete a fine-tuned model. You must have the Owner role in your organization to delete a model.
             parameters:
                 - in: path
                   name: model
@@ -2467,6 +2511,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/DeleteModelResponse"
+            summary: Delete a fine-tuned model
+
             x-oaiMeta:
                 name: Delete a fine-tuned model
                 group: models
@@ -2505,7 +2551,7 @@ paths:
             operationId: createModeration
             tags:
                 - Moderations
-            summary: Classifies if text is potentially harmful.
+            description: Classifies if text is potentially harmful.
             requestBody:
                 required: true
                 content:
@@ -2519,6 +2565,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/CreateModerationResponse"
+            summary: Create moderation
+
             x-oaiMeta:
                 name: Create moderation
                 group: moderations
@@ -2591,7 +2639,7 @@ paths:
             operationId: listAssistants
             tags:
                 - Assistants
-            summary: Returns a list of assistants.
+            description: Returns a list of assistants.
             parameters:
                 - name: limit
                   in: query
@@ -2628,6 +2676,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ListAssistantsResponse"
+            summary: List assistants
+
             x-oaiMeta:
                 name: List assistants
                 group: assistants
@@ -2722,7 +2772,7 @@ paths:
             operationId: createAssistant
             tags:
                 - Assistants
-            summary: Create an assistant with a model and instructions.
+            description: Create an assistant with a model and instructions.
             requestBody:
                 required: true
                 content:
@@ -2736,6 +2786,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/AssistantObject"
+            summary: Create assistant
+
             x-oaiMeta:
                 name: Create assistant
                 group: assistants
@@ -2882,7 +2934,7 @@ paths:
             operationId: getAssistant
             tags:
                 - Assistants
-            summary: Retrieves an assistant.
+            description: Retrieves an assistant.
             parameters:
                 - in: path
                   name: assistant_id
@@ -2897,6 +2949,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/AssistantObject"
+            summary: Retrieve assistant
+
             x-oaiMeta:
                 name: Retrieve assistant
                 group: assistants
@@ -2952,7 +3006,7 @@ paths:
             operationId: modifyAssistant
             tags:
                 - Assistants
-            summary: Modifies an assistant.
+            description: Modifies an assistant.
             parameters:
                 - in: path
                   name: assistant_id
@@ -2973,6 +3027,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/AssistantObject"
+            summary: Modify assistant
+
             x-oaiMeta:
                 name: Modify assistant
                 group: assistants
@@ -3052,7 +3108,7 @@ paths:
             operationId: deleteAssistant
             tags:
                 - Assistants
-            summary: Delete an assistant.
+            description: Delete an assistant.
             parameters:
                 - in: path
                   name: assistant_id
@@ -3067,6 +3123,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/DeleteAssistantResponse"
+            summary: Delete assistant
+
             x-oaiMeta:
                 name: Delete assistant
                 group: assistants
@@ -3109,7 +3167,7 @@ paths:
             operationId: createThread
             tags:
                 - Assistants
-            summary: Create a thread.
+            description: Create a thread.
             requestBody:
                 content:
                     application/json:
@@ -3122,6 +3180,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ThreadObject"
+            summary: Create thread
+
             x-oaiMeta:
                 name: Create thread
                 group: threads
@@ -3233,7 +3293,7 @@ paths:
             operationId: getThread
             tags:
                 - Assistants
-            summary: Retrieves a thread.
+            description: Retrieves a thread.
             parameters:
                 - in: path
                   name: thread_id
@@ -3248,6 +3308,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ThreadObject"
+            summary: Retrieve thread
+
             x-oaiMeta:
                 name: Retrieve thread
                 group: threads
@@ -3296,7 +3358,7 @@ paths:
             operationId: modifyThread
             tags:
                 - Assistants
-            summary: Modifies a thread.
+            description: Modifies a thread.
             parameters:
                 - in: path
                   name: thread_id
@@ -3317,6 +3379,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ThreadObject"
+            summary: Modify thread
+
             x-oaiMeta:
                 name: Modify thread
                 group: threads
@@ -3379,7 +3443,7 @@ paths:
             operationId: deleteThread
             tags:
                 - Assistants
-            summary: Delete a thread.
+            description: Delete a thread.
             parameters:
                 - in: path
                   name: thread_id
@@ -3394,6 +3458,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/DeleteThreadResponse"
+            summary: Delete thread
+
             x-oaiMeta:
                 name: Delete thread
                 group: threads
@@ -3436,7 +3502,7 @@ paths:
             operationId: listMessages
             tags:
                 - Assistants
-            summary: Returns a list of messages for a given thread.
+            description: Returns a list of messages for a given thread.
             parameters:
                 - in: path
                   name: thread_id
@@ -3481,6 +3547,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ListMessagesResponse"
+            summary: List messages
+
             x-oaiMeta:
                 name: List messages
                 group: threads
@@ -3566,7 +3634,7 @@ paths:
             operationId: createMessage
             tags:
                 - Assistants
-            summary: Create a message.
+            description: Create a message.
             parameters:
                 - in: path
                   name: thread_id
@@ -3587,6 +3655,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/MessageObject"
+            summary: Create message
+
             x-oaiMeta:
                 name: Create message
                 group: threads
@@ -3655,7 +3725,7 @@ paths:
             operationId: getMessage
             tags:
                 - Assistants
-            summary: Retrieve a message.
+            description: Retrieve a message.
             parameters:
                 - in: path
                   name: thread_id
@@ -3676,6 +3746,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/MessageObject"
+            summary: Retrieve message
+
             x-oaiMeta:
                 name: Retrieve message
                 group: threads
@@ -3737,7 +3809,7 @@ paths:
             operationId: modifyMessage
             tags:
                 - Assistants
-            summary: Modifies a message.
+            description: Modifies a message.
             parameters:
                 - in: path
                   name: thread_id
@@ -3764,6 +3836,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/MessageObject"
+            summary: Modify message
+
             x-oaiMeta:
                 name: Modify message
                 group: threads
@@ -3839,7 +3913,7 @@ paths:
             operationId: deleteMessage
             tags:
                 - Assistants
-            summary: Deletes a message.
+            description: Deletes a message.
             parameters:
                 - in: path
                   name: thread_id
@@ -3860,6 +3934,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/DeleteMessageResponse"
+            summary: Delete message
+
             x-oaiMeta:
                 name: Delete message
                 group: threads
@@ -3906,7 +3982,7 @@ paths:
             operationId: createThreadAndRun
             tags:
                 - Assistants
-            summary: Create a thread and run it in one request.
+            description: Create a thread and run it in one request.
             requestBody:
                 required: true
                 content:
@@ -3920,6 +3996,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/RunObject"
+            summary: Create thread and run
+
             x-oaiMeta:
                 name: Create thread and run
                 group: threads
@@ -4278,7 +4356,7 @@ paths:
             operationId: listRuns
             tags:
                 - Assistants
-            summary: Returns a list of runs belonging to a thread.
+            description: Returns a list of runs belonging to a thread.
             parameters:
                 - name: thread_id
                   in: path
@@ -4317,6 +4395,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ListRunsResponse"
+            summary: List runs
+
             x-oaiMeta:
                 name: List runs
                 group: threads
@@ -4457,7 +4537,7 @@ paths:
             operationId: createRun
             tags:
                 - Assistants
-            summary: Create a run.
+            description: Create a run.
             parameters:
                 - in: path
                   name: thread_id
@@ -4478,6 +4558,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/RunObject"
+            summary: Create run
+
             x-oaiMeta:
                 name: Create run
                 group: threads
@@ -4799,7 +4881,7 @@ paths:
             operationId: getRun
             tags:
                 - Assistants
-            summary: Retrieves a run.
+            description: Retrieves a run.
             parameters:
                 - in: path
                   name: thread_id
@@ -4820,6 +4902,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/RunObject"
+            summary: Retrieve run
+
             x-oaiMeta:
                 name: Retrieve run
                 group: threads
@@ -4899,7 +4983,7 @@ paths:
             operationId: modifyRun
             tags:
                 - Assistants
-            summary: Modifies a run.
+            description: Modifies a run.
             parameters:
                 - in: path
                   name: thread_id
@@ -4926,6 +5010,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/RunObject"
+            summary: Modify run
+
             x-oaiMeta:
                 name: Modify run
                 group: threads
@@ -5029,7 +5115,7 @@ paths:
             operationId: submitToolOuputsToRun
             tags:
                 - Assistants
-            summary: |
+            description: |
                 When a run has the `status: "requires_action"` and `required_action.type` is `submit_tool_outputs`, this endpoint can be used to submit the outputs from the tool calls once they're all completed. All outputs must be submitted in a single request.
             parameters:
                 - in: path
@@ -5057,6 +5143,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/RunObject"
+            summary: Submit tool outputs to run
+
             x-oaiMeta:
                 name: Submit tool outputs to run
                 group: threads
@@ -5285,7 +5373,7 @@ paths:
             operationId: cancelRun
             tags:
                 - Assistants
-            summary: Cancels a run that is `in_progress`.
+            description: Cancels a run that is `in_progress`.
             parameters:
                 - in: path
                   name: thread_id
@@ -5306,6 +5394,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/RunObject"
+            summary: Cancel a run
+
             x-oaiMeta:
                 name: Cancel a run
                 group: threads
@@ -5381,7 +5471,7 @@ paths:
             operationId: listRunSteps
             tags:
                 - Assistants
-            summary: Returns a list of run steps belonging to a run.
+            description: Returns a list of run steps belonging to a run.
             parameters:
                 - name: thread_id
                   in: path
@@ -5426,6 +5516,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ListRunStepsResponse"
+            summary: List run steps
+
             x-oaiMeta:
                 name: List run steps
                 group: threads
@@ -5502,7 +5594,7 @@ paths:
             operationId: getRunStep
             tags:
                 - Assistants
-            summary: Retrieves a run step.
+            description: Retrieves a run step.
             parameters:
                 - in: path
                   name: thread_id
@@ -5529,6 +5621,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/RunStepObject"
+            summary: Retrieve run step
+
             x-oaiMeta:
                 name: Retrieve run step
                 group: threads
@@ -5599,7 +5693,7 @@ paths:
             operationId: listVectorStores
             tags:
                 - Vector Stores
-            summary: Returns a list of vector stores.
+            description: Returns a list of vector stores.
             parameters:
                 - name: limit
                   in: query
@@ -5632,6 +5726,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ListVectorStoresResponse"
+            summary: List vector stores
+
             x-oaiMeta:
                 name: List vector stores
                 group: vector_stores
@@ -5701,7 +5797,7 @@ paths:
             operationId: createVectorStore
             tags:
                 - Vector Stores
-            summary: Create a vector store.
+            description: Create a vector store.
             requestBody:
                 required: true
                 content:
@@ -5715,6 +5811,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/VectorStoreObject"
+            summary: Create vector store
+
             x-oaiMeta:
                 name: Create vector store
                 group: vector_stores
@@ -5771,7 +5869,7 @@ paths:
             operationId: getVectorStore
             tags:
                 - Vector Stores
-            summary: Retrieves a vector store.
+            description: Retrieves a vector store.
             parameters:
                 - in: path
                   name: vector_store_id
@@ -5786,6 +5884,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/VectorStoreObject"
+            summary: Retrieve vector store
+
             x-oaiMeta:
                 name: Retrieve vector store
                 group: vector_stores
@@ -5828,7 +5928,7 @@ paths:
             operationId: modifyVectorStore
             tags:
                 - Vector Stores
-            summary: Modifies a vector store.
+            description: Modifies a vector store.
             parameters:
                 - in: path
                   name: vector_store_id
@@ -5849,6 +5949,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/VectorStoreObject"
+            summary: Modify vector store
+
             x-oaiMeta:
                 name: Modify vector store
                 group: vector_stores
@@ -5908,7 +6010,7 @@ paths:
             operationId: deleteVectorStore
             tags:
                 - Vector Stores
-            summary: Delete a vector store.
+            description: Delete a vector store.
             parameters:
                 - in: path
                   name: vector_store_id
@@ -5923,6 +6025,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/DeleteVectorStoreResponse"
+            summary: Delete vector store
+
             x-oaiMeta:
                 name: Delete vector store
                 group: vector_stores
@@ -5968,7 +6072,7 @@ paths:
             operationId: listVectorStoreFiles
             tags:
                 - Vector Stores
-            summary: Returns a list of vector store files.
+            description: Returns a list of vector store files.
             parameters:
                 - name: vector_store_id
                   in: path
@@ -6013,6 +6117,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ListVectorStoreFilesResponse"
+            summary: List vector store files
+
             x-oaiMeta:
                 name: List vector store files
                 group: vector_stores
@@ -6070,7 +6176,7 @@ paths:
             operationId: createVectorStoreFile
             tags:
                 - Vector Stores
-            summary: Create a vector store file by attaching a [File](/docs/api-reference/files) to a [vector store](/docs/api-reference/vector-stores/object).
+            description: Create a vector store file by attaching a [File](/docs/api-reference/files) to a [vector store](/docs/api-reference/vector-stores/object).
             parameters:
                 - in: path
                   name: vector_store_id
@@ -6093,6 +6199,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/VectorStoreFileObject"
+            summary: Create vector store file
+
             x-oaiMeta:
                 name: Create vector store file
                 group: vector_stores
@@ -6148,7 +6256,7 @@ paths:
             operationId: getVectorStoreFile
             tags:
                 - Vector Stores
-            summary: Retrieves a vector store file.
+            description: Retrieves a vector store file.
             parameters:
                 - in: path
                   name: vector_store_id
@@ -6171,6 +6279,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/VectorStoreFileObject"
+            summary: Retrieve vector store file
+
             x-oaiMeta:
                 name: Retrieve vector store file
                 group: vector_stores
@@ -6218,7 +6328,7 @@ paths:
             operationId: deleteVectorStoreFile
             tags:
                 - Vector Stores
-            summary: Delete a vector store file. This will remove the file from the vector store but the file itself will not be deleted. To delete the file, use the [delete file](/docs/api-reference/files/delete) endpoint.
+            description: Delete a vector store file. This will remove the file from the vector store but the file itself will not be deleted. To delete the file, use the [delete file](/docs/api-reference/files/delete) endpoint.
             parameters:
                 - in: path
                   name: vector_store_id
@@ -6239,6 +6349,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/DeleteVectorStoreFileResponse"
+            summary: Delete vector store file
+
             x-oaiMeta:
                 name: Delete vector store file
                 group: vector_stores
@@ -6286,7 +6398,7 @@ paths:
             operationId: createVectorStoreFileBatch
             tags:
                 - Vector Stores
-            summary: Create a vector store file batch.
+            description: Create a vector store file batch.
             parameters:
                 - in: path
                   name: vector_store_id
@@ -6309,6 +6421,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/VectorStoreFileBatchObject"
+            summary: Create vector store file batch
+
             x-oaiMeta:
                 name: Create vector store file batch
                 group: vector_stores
@@ -6369,7 +6483,7 @@ paths:
             operationId: getVectorStoreFileBatch
             tags:
                 - Vector Stores
-            summary: Retrieves a vector store file batch.
+            description: Retrieves a vector store file batch.
             parameters:
                 - in: path
                   name: vector_store_id
@@ -6392,6 +6506,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/VectorStoreFileBatchObject"
+            summary: Retrieve vector store file batch
+
             x-oaiMeta:
                 name: Retrieve vector store file batch
                 group: vector_stores
@@ -6447,7 +6563,7 @@ paths:
             operationId: cancelVectorStoreFileBatch
             tags:
                 - Vector Stores
-            summary: Cancel a vector store file batch. This attempts to cancel the processing of files in this batch as soon as possible.
+            description: Cancel a vector store file batch. This attempts to cancel the processing of files in this batch as soon as possible.
             parameters:
                 - in: path
                   name: vector_store_id
@@ -6468,6 +6584,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/VectorStoreFileBatchObject"
+            summary: Cancel vector store file batch
+
             x-oaiMeta:
                 name: Cancel vector store file batch
                 group: vector_stores
@@ -6524,7 +6642,7 @@ paths:
             operationId: listFilesInVectorStoreBatch
             tags:
                 - Vector Stores
-            summary: Returns a list of vector store files in a batch.
+            description: Returns a list of vector store files in a batch.
             parameters:
                 - name: vector_store_id
                   in: path
@@ -6575,6 +6693,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ListVectorStoreFilesResponse"
+            summary: List vector store files in a batch
+
             x-oaiMeta:
                 name: List vector store files in a batch
                 group: vector_stores
@@ -6633,7 +6753,7 @@ paths:
 
     /batches:
         post:
-            summary: Creates and executes a batch from an uploaded file of requests
+            description: Creates and executes a batch from an uploaded file of requests
             operationId: createBatch
             tags:
                 - Batch
@@ -6682,6 +6802,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/Batch"
+            summary: Create batch
+
             x-oaiMeta:
                 name: Create batch
                 group: batch
@@ -6756,7 +6878,7 @@ paths:
             operationId: listBatches
             tags:
                 - Batch
-            summary: List your organization's batches.
+            description: List your organization's batches.
             parameters:
                 - in: query
                   name: after
@@ -6778,6 +6900,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/ListBatchesResponse"
+            summary: List batch
+
             x-oaiMeta:
                 name: List batch
                 group: batch
@@ -6852,7 +6976,7 @@ paths:
             operationId: retrieveBatch
             tags:
                 - Batch
-            summary: Retrieves a batch.
+            description: Retrieves a batch.
             parameters:
                 - in: path
                   name: batch_id
@@ -6867,6 +6991,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/Batch"
+            summary: Retrieve batch
+
             x-oaiMeta:
                 name: Retrieve batch
                 group: batch
@@ -6930,7 +7056,7 @@ paths:
             operationId: cancelBatch
             tags:
                 - Batch
-            summary: Cancels an in-progress batch. The batch will be in status `cancelling` for up to 10 minutes, before changing to `cancelled`, where it will have partial results (if any) available in the output file.
+            description: Cancels an in-progress batch. The batch will be in status `cancelling` for up to 10 minutes, before changing to `cancelled`, where it will have partial results (if any) available in the output file.
             parameters:
                 - in: path
                   name: batch_id
@@ -6945,6 +7071,8 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/Batch"
+            summary: Cancel batch
+
             x-oaiMeta:
                 name: Cancel batch
                 group: batch


### PR DESCRIPTION
This PR updates `summary` field names to `description` in info objects.

The OpenAPI specification indeed [specifies](https://spec.openapis.org/oas/v3.1.0#fixed-fields-0):

Field Name | Type | Description
-- | -- | --
summary | string | A short summary of the API.
description | string | A description of the API. CommonMark syntax MAY be used for rich text representation.

As multiple current summary fields include Markdown descriptions, this change makes it possible to nicely render the definition file in standard vendor tooling on the market. Example: https://bump.sh/christophedujarric/doc/openai