### PR TITLE
Move model parameter above input/messages/file to make downstream clients more efficient for OpenAI API implementors

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7811,12 +7811,6 @@ components:
         CreateChatCompletionRequest:
             type: object
             properties:
-                messages:
-                    description: A list of messages comprising the conversation so far. [Example Python code](https://cookbook.openai.com/examples/how_to_format_inputs_to_chatgpt_models).
-                    type: array
-                    minItems: 1
-                    items:
-                        $ref: "#/components/schemas/ChatCompletionRequestMessage"
                 model:
                     description: ID of the model to use. See the [model endpoint compatibility](/docs/models/model-endpoint-compatibility) table for details on which models work with the Chat API.
                     example: "gpt-4-turbo"
@@ -7848,6 +7842,12 @@ components:
                                   "gpt-3.5-turbo-16k-0613",
                               ]
                     x-oaiTypeLabel: string
+                messages:
+                    description: A list of messages comprising the conversation so far. [Example Python code](https://cookbook.openai.com/examples/how_to_format_inputs_to_chatgpt_models).
+                    type: array
+                    minItems: 1
+                    items:
+                        $ref: "#/components/schemas/ChatCompletionRequestMessage"
                 frequency_penalty:
                     type: number
                     default: 0
@@ -8871,6 +8871,19 @@ components:
             type: object
             additionalProperties: false
             properties:
+                model:
+                    description: *model_description
+                    example: "text-embedding-3-small"
+                    anyOf:
+                        - type: string
+                        - type: string
+                          enum:
+                              [
+                                  "text-embedding-ada-002",
+                                  "text-embedding-3-small",
+                                  "text-embedding-3-large",
+                              ]
+                    x-oaiTypeLabel: string
                 input:
                     description: |
                         Input text to embed, encoded as a string or array of tokens. To embed multiple inputs in a single request, pass an array of strings or array of token arrays. The input must not exceed the max input tokens for the model (8192 tokens for `text-embedding-ada-002`), cannot be an empty string, and any array must be 2048 dimensions or less. [Example Python code](https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken) for counting tokens.
@@ -8910,19 +8923,6 @@ components:
                                   type: integer
                           example: "[[1212, 318, 257, 1332, 13]]"
                     x-oaiExpandable: true
-                model:
-                    description: *model_description
-                    example: "text-embedding-3-small"
-                    anyOf:
-                        - type: string
-                        - type: string
-                          enum:
-                              [
-                                  "text-embedding-ada-002",
-                                  "text-embedding-3-small",
-                                  "text-embedding-3-large",
-                              ]
-                    x-oaiTypeLabel: string
                 encoding_format:
                     description: "The format to return the embeddings in. Can be either `float` or [`base64`](https://pypi.org/project/pybase64/)."
                     example: "float"
@@ -8977,12 +8977,6 @@ components:
             type: object
             additionalProperties: false
             properties:
-                file:
-                    description: |
-                        The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
-                    type: string
-                    x-oaiTypeLabel: file
-                    format: binary
                 model:
                     description: |
                         ID of the model to use. Only `whisper-1` (which is powered by our open source Whisper V2 model) is currently available.
@@ -8992,6 +8986,12 @@ components:
                         - type: string
                           enum: ["whisper-1"]
                     x-oaiTypeLabel: string
+                file:
+                    description: |
+                        The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+                    type: string
+                    x-oaiTypeLabel: file
+                    format: binary
                 language:
                     description: |
                         The language of the input audio. Supplying the input language in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format will improve accuracy and latency.
@@ -9147,12 +9147,6 @@ components:
             type: object
             additionalProperties: false
             properties:
-                file:
-                    description: |
-                        The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
-                    type: string
-                    x-oaiTypeLabel: file
-                    format: binary
                 model:
                     description: |
                         ID of the model to use. Only `whisper-1` (which is powered by our open source Whisper V2 model) is currently available.
@@ -9162,6 +9156,12 @@ components:
                         - type: string
                           enum: ["whisper-1"]
                     x-oaiTypeLabel: string
+                file:
+                    description: |
+                        The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+                    type: string
+                    x-oaiTypeLabel: file
+                    format: binary
                 prompt:
                     description: |
                         An optional text to guide the model's style or continue a previous audio segment. The [prompt](/docs/guides/speech-to-text/prompting) should be in English.


### PR DESCRIPTION
At $WORK we offer an OpenAI compatible API and route based on the model parameter.
Some clients, like the openai-python client, are generated from this API spec, so the python client always sends the input before the model.
This leads to us buffering the whole input, before being able to parse the model and route to the correct machine hosting that model. I filed an [issue with the python client](https://github.com/openai/openai-python/issues/1525), but it would be hard to change there and it may not be the only project relying on the order of the API spec.

Someone would have to confirm, that this change actually changes the order in requests of openai-python. I tried but did not get far, since they use stainless in a github action.

I think it would be good to change the order of the parameters in the API spec to an improved order, so that downstream clients adopt it. Then, providers of the OpenAI API will be able to route larger requests and with less overall latency.
I wrote some more details in the https://github.com/openai/openai-python/issues/1525 issue.

I changed the spec how I am imagining it currently only for CreateChatCompletionRequest, CreateEmbeddingRequest, CreateTranscriptionRequest, and CreateTranslationRequest. Those are the ones that I have looked into, but the issue may apply to other requests as well, and to other "meta" parameters apart from model.