### PR TITLE
feat: Make ParalleToolCalls nullable

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7664,7 +7664,6 @@ components:
         ParallelToolCalls:
             description: Whether to enable [parallel function calling](/docs/guides/function-calling/parallel-function-calling) during tool use.
             type: boolean
-            default: null
             nullable: true
 
         ChatCompletionMessageToolCalls:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7664,7 +7664,8 @@ components:
         ParallelToolCalls:
             description: Whether to enable [parallel function calling](/docs/guides/function-calling/parallel-function-calling) during tool use.
             type: boolean
-            default: true
+            default: null
+            nullable: true
 
         ChatCompletionMessageToolCalls:
             type: array


### PR DESCRIPTION
It should be nullable and null by default because API will return error for simple chat requests:
```json
{
  "error": {
    "message": "Invalid value for 'parallel_tool_calls': 'parallel_tool_calls' is only allowed when 'tools' are specified.",
    "type": "invalid_request_error",
    "param": "parallel_tool_calls",
    "code": null
  }
}
```