### PR TITLE
Fix the vector store object's last_error.codes

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12933,10 +12933,9 @@ components:
                             description: One of `server_error` or `rate_limit_exceeded`.
                             enum:
                                 [
-                                    "internal_error",
-                                    "file_not_found",
-                                    "parsing_error",
-                                    "unhandled_mime_type",
+                                    "server_error",
+                                    "unsupported_file",
+                                    "invalid_file",
                                 ]
                         message:
                             type: string


### PR DESCRIPTION
This fixes issue reported here - https://github.com/openai/openai-node/issues/939 where the VectorStoreObject's last_error.codes were different from what the API response received.