### PR TITLE
Add /v1/audit_logs API documentation

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7228,38 +7228,51 @@ paths:
                             "batch_description": "Nightly eval job",
                           }
                         }
-    /audit_logs:
+    /organization/audit_logs:
         get:
             summary: List user actions and configuration changes within this organization.
             operationId: listAuditLogs
             tags:
                 - Audit Logs
             parameters:
-                - name: project.ids[]
+                - name: effective_at
+                  in: query
+                  description: Return only events whose effective_at (Unix seconds) is in this range. Properties are gte (effective_at.gte) and lte (effective_at.lte).
+                  required: false
+                  schema:
+                      type: object
+                      properties:
+                        gte:
+                          type: integer
+                          description: Return only events whose effective_at (Unix seconds) is greater than or equal to this value.
+                        lte:
+                          type: integer
+                          description: Return only events whose effective_at (Unix seconds) is less than or equal to this value.
+                - name: project_ids[]
                   in: query
                   description: Return only events for these projects.
                   required: false
                   schema:
                       type: string
-                - name: event.types[]
+                - name: event_types[]
                   in: query
                   description: Return only events for these types. For example, `project.created`.
                   required: false
                   schema:
                       type: string
-                - name: actor.ids[]
+                - name: actor_ids[]
                   in: query
                   description: Return only events performed by these actors. Can be a user id, a service account id, or an api key tracking id.
                   required: false
                   schema:
                       type: string
-                - name: actor.emails[]
+                - name: actor_emails[]
                   in: query
                   description: Return only events performed by users with these emails.
                   required: false
                   schema:
                       type: string
-                - name: resource.ids[]
+                - name: resource_ids[]
                   in: query
                   description: Return only events performed on these targets. For example, a project id updated.
                   required: false
@@ -7288,7 +7301,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: "#/components/schemas/AuditLog"
+                                $ref: "#/components/schemas/ListAuditLogsResponse"
             x-oaiMeta:
                 name: List audit logs
                 group: audit-logs
@@ -7296,7 +7309,7 @@ paths:
                 examples:
                     request:
                         curl: |
-                            curl https://api.openai.com/v1/audit_logs \
+                            curl https://api.openai.com/v1/organization/audit_logs \
                             -H "Authorization: Bearer $OPENAI_API_KEY" \
                             -H "Content-Type: application/json" \
                     response: |
@@ -10611,8 +10624,7 @@ components:
                     x-oaiTypeLabel: map
                     nullable: true
                 temperature:
-                    description: &run_temperature_description |
-                        What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.
+                    description: *run_temperature_description
                     type: number
                     minimum: 0
                     maximum: 2
@@ -10626,10 +10638,7 @@ components:
                     default: 1
                     example: 1
                     nullable: true
-                    description: &run_top_p_description |
-                        An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
-
-                        We generally recommend altering this or temperature but not both.
+                    description: *run_top_p_description
                 response_format:
                     $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
                     nullable: true
@@ -10717,10 +10726,7 @@ components:
                     default: 1
                     example: 1
                     nullable: true
-                    description: &run_top_p_description |
-                        An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
-
-                        We generally recommend altering this or temperature but not both.
+                    description: *run_top_p_description
                 response_format:
                     $ref: "#/components/schemas/AssistantsApiResponseFormatOption"
                     nullable: true
@@ -11192,10 +11198,7 @@ components:
                     default: 1
                     example: 1
                     nullable: true
-                    description: &run_top_p_description |
-                        An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.
-
-                        We generally recommend altering this or temperature but not both.
+                    description: *run_top_p_description
                 stream:
                     type: boolean
                     nullable: true
@@ -14022,7 +14025,7 @@ components:
                     $ref: "#/components/schemas/AuditLogEventType"
                     
                 effective_at:
-                    type: int
+                    type: integer
                     description: The Unix timestamp (in seconds) of the event.
                 project:
                     type: object
@@ -14049,6 +14052,8 @@ components:
                             properties:
                                 scopes:
                                     type: array
+                                    items:
+                                        type: string
                                     description: A list of scopes allowed for the API key, e.g. `["api.model.request"]`
                 api_key.updated:
                     type: object
@@ -14063,6 +14068,8 @@ components:
                             properties:
                                 scopes:
                                     type: array
+                                    items:
+                                        type: string
                                     description: A list of scopes allowed for the API key, e.g. `["api.model.request"]`                                    
                 api_key.deleted:
                     type: object
@@ -14574,7 +14581,7 @@ x-oaiMeta:
                 path: object
         - id: audit-logs
           title: Audit logs
-          description: Logs of user actions and configuration changes within this organization
+          description: Logs of user actions and configuration changes within this organization.
           navigationGroup: endpoints
           sections:
               - type: endpoint

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.0
 info:
     title: OpenAI API
     description: The OpenAI REST API. Please see https://platform.openai.com/docs/api-reference for more details.
-    version: "2.1.0"
+    version: "2.2.0"
     termsOfService: https://openai.com/policies/terms-of-use
     contact:
         name: OpenAI Support
@@ -37,6 +37,8 @@ tags:
       description: List and describe the various models available in the API.
     - name: Moderations
       description: Given a input text, outputs if the model classifies it as potentially harmful.
+    - name: Audit Logs
+      description: List user actions and configuration changes within this organization.
 paths:
     # Note: When adding an endpoint, make sure you also add it in the `groups` section, in the end of this file,
     # under the appropriate group
@@ -7226,6 +7228,128 @@ paths:
                             "batch_description": "Nightly eval job",
                           }
                         }
+    /audit_logs:
+        get:
+            summary: List user actions and configuration changes within this organization.
+            operationId: listAuditLogs
+            tags:
+                - Audit Logs
+            parameters:
+                - name: project.ids[]
+                  in: query
+                  description: Return only events for these projects.
+                  required: false
+                  schema:
+                      type: string
+                - name: event.types[]
+                  in: query
+                  description: Return only events for these types. For example, `project.created`.
+                  required: false
+                  schema:
+                      type: string
+                - name: actor.ids[]
+                  in: query
+                  description: Return only events performed by these actors. Can be a user id, a service account id, or an api key tracking id.
+                  required: false
+                  schema:
+                      type: string
+                - name: actor.emails[]
+                  in: query
+                  description: Return only events performed by users with these emails.
+                  required: false
+                  schema:
+                      type: string
+                - name: resource.ids[]
+                  in: query
+                  description: Return only events performed on these targets. For example, a project id updated.
+                  required: false
+                  schema:
+                      type: string
+                - name: limit
+                  in: query
+                  description: A limit on the number of objects to be returned. Limit can range between 1 and 1000, and the default is 20.
+                  required: false
+                  schema:
+                      type: integer
+                      default: 20
+                - name: after
+                  in: query
+                  description: *pagination_after_param_description
+                  schema:
+                      type: string
+                - name: before
+                  in: query
+                  description: *pagination_before_param_description
+                  schema:
+                      type: string
+            responses:
+                "200":
+                    description: Audit logs listed successfully.
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/AuditLog"
+            x-oaiMeta:
+                name: List audit logs
+                group: audit-logs
+                returns: A list of paginated [Audit Log](/docs/api-reference/audit-logs/object) objects.
+                examples:
+                    request:
+                        curl: |
+                            curl https://api.openai.com/v1/audit_logs \
+                            -H "Authorization: Bearer $OPENAI_API_KEY" \
+                            -H "Content-Type: application/json" \
+                    response: |
+                        {
+                            "object": "list",
+                            "data": [
+                                {
+                                    "id": "req_xxx_20240101",
+                                    "type": "api_key.created",
+                                    "effective_at": 1720804090,
+                                    "actor": {
+                                        "type": "session",
+                                        "session": {
+                                            "user": {
+                                                "id": "user-xxx",
+                                                "email": "user@example.com"
+                                            },
+                                            "ip_address": "127.0.0.1"
+                                        }
+                                    },
+                                    "api_key.created": {
+                                        "id": "key_xxxx",
+                                        "data": {
+                                            "scopes": ["resource.operation"]
+                                        }
+                                    },
+                                },
+                                {
+                                    "id": "req_yyy__20240101",
+                                    "type": "api_key.updated",
+                                    "effective_at": 1720804190,
+                                    "actor": {
+                                        "type": "session",
+                                        "session": {
+                                            "user": {
+                                                "id": "user-xxx",
+                                                "email": "user@example.com"
+                                            },
+                                            "ip_address": "127.0.0.1"
+                                        }
+                                    },
+                                    "api_key.updated": {
+                                        "id": "key_xxxx",
+                                        "data": {
+                                            "scopes": ["resource_2.operation_2"]
+                                        }
+                                    },
+                                }
+                            ],
+                            "first_id": "req_xxx__20240101",
+                            "last_id": "req_yyy__20240101",
+                            "has_more": true
+                        }
 
 components:
     securitySchemes:
@@ -12933,10 +13057,9 @@ components:
                             description: One of `server_error` or `rate_limit_exceeded`.
                             enum:
                                 [
-                                    "internal_error",
-                                    "file_not_found",
-                                    "parsing_error",
-                                    "unhandled_mime_type",
+                                    "server_error",
+                                    "unsupported_file",
+                                    "invalid_file",
                                 ]
                         message:
                             type: string
@@ -13781,6 +13904,417 @@ components:
                 - data
                 - has_more
 
+        AuditLogActorServiceAccount:
+            type: object
+            description: The service account that performed the audit logged action.
+            properties:
+                id:
+                    type: string
+                    description: The service account id.
+
+        AuditLogActorUser:
+            type: object
+            description: The user who performed the audit logged action.
+            properties:
+                id:
+                    type: string
+                    description: The user id.
+                email:
+                    type: string
+                    description: The user email.
+
+        AuditLogActorApiKey:
+            type: object
+            description: The API Key used to perform the audit logged action.
+            properties:
+                id:
+                    type: string
+                    description: The tracking id of the API key.
+                type:
+                    type: string
+                    description: The type of API key. Can be either `user` or `service_account`.
+                    enum: ["user", "service_account"]
+                user:
+                    $ref: "#/components/schemas/AuditLogActorUser"
+                service_account:
+                    $ref: "#/components/schemas/AuditLogActorServiceAccount"
+
+        AuditLogActorSession:
+            type: object
+            description: The session in which the audit logged action was performed.
+            properties:
+                user:
+                    $ref: "#/components/schemas/AuditLogActorUser"
+                ip_address:
+                    type: string
+                    description: The IP address from which the action was performed.
+
+        AuditLogActor:
+            type: object
+            description: The actor who performed the audit logged action.
+            properties:
+                type:
+                    type: string
+                    description: The type of actor. Is either `session` or `api_key`.
+                    enum: ["session", "api_key"]
+                session:
+                    type: object
+                    $ref: "#/components/schemas/AuditLogActorSession"
+                api_key:
+                    type: object
+                    $ref: "#/components/schemas/AuditLogActorApiKey"
+                    
+                    
+        AuditLogEventType:
+            type: string
+            description: The event type.
+            x-oaiExpandable: true
+            oneOf:
+                - type: string
+                  title: api_key.created
+                - type: string
+                  title: api_key.updated
+                - type: string
+                  title: api_key.deleted
+                - type: string
+                  title: invite.sent
+                - type: string
+                  title: invite.accepted
+                - type: string
+                  title: invite.deleted
+                - type: string
+                  title: login.succeeded
+                - type: string
+                  title: login.failed
+                - type: string
+                  title: logout.succeeded
+                - type: string
+                  title: logout.failed
+                - type: string
+                  title: organization.updated
+                - type: string
+                  title: project.created
+                - type: string
+                  title: project.updated
+                - type: string
+                  title: project.archived
+                - type: string
+                  title: service_account.created
+                - type: string
+                  title: service_account.updated
+                - type: string
+                  title: service_account.deleted
+                - type: string
+                  title: user.added
+                - type: string
+                  title: user.updated
+                - type: string
+                  title: user.deleted
+
+        AuditLog:
+            type: object
+            description: A log of a user action or configuration change within this organization.
+            properties:
+                id:
+                    type: string
+                    description: The ID of this log.
+                type:
+                    $ref: "#/components/schemas/AuditLogEventType"
+                    
+                effective_at:
+                    type: int
+                    description: The Unix timestamp (in seconds) of the event.
+                project:
+                    type: object
+                    description: The project that the action was scoped to. Absent for actions not scoped to projects.
+                    properties:
+                        id:
+                            type: string
+                            description: The project ID.
+                        name:
+                            type: string
+                            description: The project title.
+                actor:
+                    $ref: "#/components/schemas/AuditLogActor" 
+                api_key.created:
+                    type: object
+                    description: The details for events with this `type`.
+                    properties:
+                        id:
+                            type: string
+                            description: The tracking ID of the API key.
+                        data:
+                            type: object
+                            description: The payload used to create the API key.
+                            properties:
+                                scopes:
+                                    type: array
+                                    description: A list of scopes allowed for the API key, e.g. `["api.model.request"]`
+                api_key.updated:
+                    type: object
+                    description: The details for events with this `type`.
+                    properties:
+                        id:
+                            type: string
+                            description: The tracking ID of the API key.
+                        changes_requested:
+                            type: object
+                            description: The payload used to update the API key.
+                            properties:
+                                scopes:
+                                    type: array
+                                    description: A list of scopes allowed for the API key, e.g. `["api.model.request"]`                                    
+                api_key.deleted:
+                    type: object
+                    description: The details for events with this `type`.
+                    properties:
+                        id:
+                            type: string
+                            description: The tracking ID of the API key.
+                invite.sent:
+                    type: object
+                    description: The details for events with this `type`.
+                    properties:
+                        id:
+                            type: string
+                            description: The ID of the invite.
+                        data:
+                            type: object
+                            description: The payload used to create the invite.
+                            properties:
+                                email:
+                                    type: string
+                                    description: The email invited to the organization.
+                                role:
+                                    type: string
+                                    description: The role the email was invited to be. Is either `owner` or `member`.
+                invite.accepted:
+                    type: object
+                    description: The details for events with this `type`.
+                    properties:
+                        id:
+                            type: string
+                            description: The ID of the invite.
+                invite.deleted:
+                    type: object
+                    description: The details for events with this `type`.
+                    properties:
+                        id:
+                            type: string
+                            description: The ID of the invite.
+                login.failed:
+                    type: object
+                    description: The details for events with this `type`.
+                    properties:
+                        error_code:
+                            type: string
+                            description: The error code of the failure.
+                        error_message:
+                            type: string
+                            description: The error message of the failure.                  
+                logout.failed:
+                    type: object
+                    description: The details for events with this `type`.
+                    properties:
+                        error_code:
+                            type: string
+                            description: The error code of the failure.
+                        error_message:
+                            type: string
+                            description: The error message of the failure. 
+                organization.updated:
+                    type: object
+                    description: The details for events with this `type`.
+                    properties:
+                        id:
+                            type: string
+                            description: The organization ID.
+                        changes_requested:
+                            type: object
+                            description: The payload used to update the organization settings.
+                            properties:
+                                title:
+                                    type: string
+                                    description: The organization title.
+                                description:
+                                    type: string
+                                    description: The organization description.
+                                name:
+                                    type: string
+                                    description: The organization name.
+                                settings:
+                                    type: object
+                                    properties:
+                                        threads_ui_visibility:
+                                            type: string
+                                            description: Visibility of the threads page which shows messages created with the Assistants API and Playground. One of `ANY_ROLE`, `OWNERS`, or `NONE`.
+                                        usage_dashboard_visibility:
+                                            type: string
+                                            description: Visibility of the usage dashboard which shows activity and costs for your organization. One of `ANY_ROLE` or `OWNERS`.
+                project.created:
+                    type: object
+                    description: The details for events with this `type`.
+                    properties:
+                        id:
+                            type: string
+                            description: The project ID.
+                        data:
+                            type: object
+                            description: The payload used to create the project.
+                            properties:
+                                name:
+                                    type: string
+                                    description: The project name.
+                                title:
+                                    type: string
+                                    description: The title of the project as seen on the dashboard.
+                project.updated:
+                    type: object
+                    description: The details for events with this `type`.
+                    properties:
+                        id:
+                            type: string
+                            description: The project ID.
+                        changes_requested:
+                            type: object
+                            description: The payload used to update the project.
+                            properties:
+                                title:
+                                    type: string
+                                    description: The title of the project as seen on the dashboard.
+                project.archived:
+                    type: object
+                    description: The details for events with this `type`.
+                    properties:
+                        id:
+                            type: string
+                            description: The project ID.
+                service_account.created:
+                    type: object
+                    description: The details for events with this `type`.
+                    properties:
+                        id:
+                            type: string
+                            description: The service account ID.
+                        data:
+                            type: object
+                            description: The payload used to create the service account.
+                            properties:
+                                role:
+                                    type: string
+                                    description: The role of the service account. Is either `owner` or `member`.
+                service_account.updated:
+                    type: object
+                    description: The details for events with this `type`.
+                    properties:
+                        id:
+                            type: string
+                            description: The service account ID.
+                        changes_requested:
+                            type: object
+                            description: The payload used to updated the service account.
+                            properties:
+                                role:
+                                    type: string
+                                    description: The role of the service account. Is either `owner` or `member`.
+                service_account.deleted:
+                    type: object
+                    description: The details for events with this `type`.
+                    properties:
+                        id:
+                            type: string
+                            description: The service account ID.
+                user.added:
+                    type: object
+                    description: The details for events with this `type`.
+                    properties:
+                        id:
+                            type: string
+                            description: The user ID.
+                        data:
+                            type: object
+                            description: The payload used to add the user to the project.
+                            properties:
+                                role:
+                                    type: string
+                                    description: The role of the user. Is either `owner` or `member`.
+                user.updated:
+                    type: object
+                    description: The details for events with this `type`.
+                    properties:
+                        id:
+                            type: string
+                            description: The project ID.
+                        changes_requested:
+                            type: object
+                            description: The payload used to update the user.
+                            properties:
+                                role:
+                                    type: string
+                                    description: The role of the user. Is either `owner` or `member`.
+                user.deleted:
+                    type: object
+                    description: The details for events with this `type`.
+                    properties:
+                        id:
+                            type: string
+                            description: The user ID.
+            required:
+                - id
+                - type
+                - effective_at
+                - actor
+            x-oaiMeta:
+                name: The audit log object
+                example: |
+                    {
+                        "id": "req_xxx_20240101",
+                        "type": "api_key.created",
+                        "effective_at": 1720804090,
+                        "actor": {
+                            "type": "session",
+                            "session": {
+                                "user": {
+                                    "id": "user-xxx",
+                                    "email": "user@example.com"
+                                },
+                                "ip_address": "127.0.0.1"
+                            }
+                        },
+                        "api_key.created": {
+                            "id": "key_xxxx",
+                            "data": {
+                                "scopes": ["resource.operation"]
+                            }
+                        }
+                    }
+
+        ListAuditLogsResponse:
+            type: object
+            properties:
+                object:
+                    type: string
+                    enum: [list]
+                data:
+                    type: array
+                    items:
+                        $ref: "#/components/schemas/AuditLog"
+                first_id:
+                    type: string
+                    example: "req_xxxx"
+                last_id:
+                    type: string
+                    example: "req_xxxx"
+                has_more:
+                    type: boolean
+
+            required:
+                - object
+                - data
+                - first_id
+                - last_id
+                - has_more
+
 security:
     - ApiKeyAuth: []
 
@@ -14037,6 +14571,17 @@ x-oaiMeta:
                 path: create
               - type: object
                 key: CreateModerationResponse
+                path: object
+        - id: audit-logs
+          title: Audit logs
+          description: Logs of user actions and configuration changes within this organization
+          navigationGroup: endpoints
+          sections:
+              - type: endpoint
+                key: listAuditLogs
+                path: list
+              - type: object
+                key: AuditLog
                 path: object
         - id: assistants
           title: Assistants

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7237,7 +7237,7 @@ paths:
             parameters:
                 - name: effective_at
                   in: query
-                  description: Return only events whose effective_at (Unix seconds) is in this range. Properties are gte (effective_at.gte) and lte (effective_at.lte).
+                  description: Return only events whose effective_at (Unix seconds) is in this range.
                   required: false
                   schema:
                       type: object
@@ -7253,31 +7253,41 @@ paths:
                   description: Return only events for these projects.
                   required: false
                   schema:
-                      type: string
+                      type: array
+                      items:
+                          type: string
                 - name: event_types[]
                   in: query
-                  description: Return only events for these types. For example, `project.created`.
+                  description: Return only events with a `type` in one of these values. For example, `project.created`. For all options, see the documentation for the [audit log object](/docs/api-reference/audit-logs/object).
                   required: false
                   schema:
-                      type: string
+                      type: array
+                      items:
+                          $ref: "#/components/schemas/AuditLogEventType"
                 - name: actor_ids[]
                   in: query
                   description: Return only events performed by these actors. Can be a user id, a service account id, or an api key tracking id.
                   required: false
                   schema:
-                      type: string
+                      type: array
+                      items:
+                          type: string
                 - name: actor_emails[]
                   in: query
                   description: Return only events performed by users with these emails.
                   required: false
                   schema:
-                      type: string
+                      type: array
+                      items:
+                          type: string
                 - name: resource_ids[]
                   in: query
                   description: Return only events performed on these targets. For example, a project id updated.
                   required: false
                   schema:
-                      type: string
+                      type: array
+                      items:
+                          type: string
                 - name: limit
                   in: query
                   description: A limit on the number of objects to be returned. Limit can range between 1 and 1000, and the default is 20.
@@ -13972,47 +13982,27 @@ components:
             type: string
             description: The event type.
             x-oaiExpandable: true
-            oneOf:
-                - type: string
-                  title: api_key.created
-                - type: string
-                  title: api_key.updated
-                - type: string
-                  title: api_key.deleted
-                - type: string
-                  title: invite.sent
-                - type: string
-                  title: invite.accepted
-                - type: string
-                  title: invite.deleted
-                - type: string
-                  title: login.succeeded
-                - type: string
-                  title: login.failed
-                - type: string
-                  title: logout.succeeded
-                - type: string
-                  title: logout.failed
-                - type: string
-                  title: organization.updated
-                - type: string
-                  title: project.created
-                - type: string
-                  title: project.updated
-                - type: string
-                  title: project.archived
-                - type: string
-                  title: service_account.created
-                - type: string
-                  title: service_account.updated
-                - type: string
-                  title: service_account.deleted
-                - type: string
-                  title: user.added
-                - type: string
-                  title: user.updated
-                - type: string
-                  title: user.deleted
+            enum:
+                - api_key.created
+                - api_key.updated
+                - api_key.deleted
+                - invite.sent
+                - invite.accepted
+                - invite.deleted
+                - login.succeeded
+                - login.failed
+                - logout.succeeded
+                - logout.failed
+                - organization.updated
+                - project.created
+                - project.updated
+                - project.archived
+                - service_account.created
+                - service_account.updated
+                - service_account.deleted
+                - user.added
+                - user.updated
+                - user.deleted
 
         AuditLog:
             type: object


### PR DESCRIPTION
Adding documentation for new API endpoint.

Ran `yarn sync-openapi-spec` after making the changes to api-definition.yaml in https://github.com/openai/openai/pull/130362.

![Screenshot 2024-07-21 at 10 54 34 PM](https://github.com/user-attachments/assets/44207bc2-bb85-4bdf-a432-66352cb17df6)
![Screenshot 2024-07-21 at 10 56 03 PM](https://github.com/user-attachments/assets/68c15286-1618-408e-85ff-e9ad8ec2f1fc)
![Screenshot 2024-07-21 at 10 57 01 PM](https://github.com/user-attachments/assets/1e9814a0-3da6-4fc1-a877-bc4e46699c78)
