### PR TITLE
fix: Restore 'required' to Upload.object (probable merge collision)

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9649,6 +9649,7 @@ components:
                     nullable: true
                     description: The ready File object after the Upload is completed.
             required:
+                - object
                 - bytes
                 - created_at
                 - expires_at


### PR DESCRIPTION
- Commit 8157e872b396cbda43ddea771957508ac38ea62f made the type identifier `object` required for the new `Upload` schema type
- Commit cd3c3feb77931b5fd1e8b9c1eb5fb1697821a0d0 incidentally reverted that change
- This just repeats the addition made by @RobertCraigie in 8157e872b396cbda43ddea771957508ac38ea62f 