### PR TITLE
add unsupported_file error type for VectorStoreFileObject

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12937,6 +12937,7 @@ components:
                                     "file_not_found",
                                     "parsing_error",
                                     "unhandled_mime_type",
+                                    "unsupported_file",
                                 ]
                         message:
                             type: string


### PR DESCRIPTION
I tried listing my vector store file and received an error not part of the spec.

Doing the API call manually I saw that the status code returned is not yet included in the openAPI yaml.

```bash
curl https://api.openai.com/v1/vector_stores/vs_Y.../files -H 'OpenAI-Beta: assistants=v2'
```
the response.
```json
    {
      "id": "file-hAV...",
      "object": "vector_store.file",
      "usage_bytes": 0,
      "created_at": 1722070582,
      "vector_store_id": "vs_....",
      "status": "failed",
      "last_error": {
        "code": "unsupported_file",
        "message": "The file type is not supported."
      },
      "chunking_strategy": {
        "type": "static",
        "static": {
          "max_chunk_size_tokens": 800,
          "chunk_overlap_tokens": 400
        }
      }
    },
```

So I added the status code to the enum.