### PR TITLE
Fix VectorStoreFileObject `last_error` code description

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14982,7 +14982,7 @@ components:
                     properties:
                         code:
                             type: string
-                            description: One of `server_error` or `rate_limit_exceeded`.
+                            description: One of `server_error`, `unsupported_file` or `invalid_file`.
                             enum:
                                 [
                                     "server_error",


### PR DESCRIPTION
I regularly refer to this `openapi.yaml` specification for some of my work, and today I noticed that the `description` of the`code` property in **VectorStoreFileObject**'s `last_error` does not match with its corresponding enum values.

In this PR, I have modified that description to align with the valid values per the latest specs.