### PR TITLE
Add CreateChatCompletionStreamResponse as an Event-stream Response Type to the /Chat/completions Endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -61,6 +61,9 @@ paths:
                         application/json:
                             schema:
                                 $ref: "#/components/schemas/CreateChatCompletionResponse"
+                        text/event-stream:
+                            schema:
+                                $ref: "#/components/schemas/CreateChatCompletionStreamResponse"
 
             x-oaiMeta:
                 name: Create chat completion


### PR DESCRIPTION
In the `/chat/completions` endpoint definition under `x-oaiMeta` it says:

```yaml
x-oaiMeta:
    name: Create chat completion
    group: chat
    returns: |
        Returns a [chat completion](/docs/api-reference/chat/object) object, or a streamed sequence of [chat completion chunk](/docs/api-reference/chat/streaming) objects if the request is streamed.
```

The "streamed sequence of chat completion chunk objects" refers, I believe, to the `CreateChatCompletionStreamResponse` type, which is defined, but never explicitly linked to the `createChatCompletionRequest()` function.

Since it is never defined that `createChatCompletionRequest()` may return a stream of chunk objects, tools such as the [swift-openapi-generator package](https://github.com/apple/swift-openapi-generator), which I have been using to implement the OpenAI OpenAPI spec, cannot generate the correct code for the spec.
For more context, see [the corresponding issue in the swift-openapi-generator repo](https://github.com/apple/swift-openapi-generator/issues/614).

This PR links the `CreateChatCompletionStreamResponse` type to the `createChatCompletion()` function.
