### PR TITLE
Fix `ResponseFormatJsonSchema`

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9381,7 +9381,6 @@ components:
                             default: false
                             description:  Whether to enable strict schema adherence when generating the output. If set to true, the model will always follow the exact schema defined in the `schema` field. Only a subset of JSON Schema is supported when `strict` is `true`. To learn more, read the [Structured Outputs guide](/docs/guides/structured-outputs).
                     required:
-                        - type
                         - name
             required:
                 - type


### PR DESCRIPTION
`type` is not a field in the `json_schema` object