### PR TITLE
Correct service_tier in chat response

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -10076,8 +10076,8 @@ components:
                 service_tier:
                     description: The service tier used for processing the request. This field is only included if the `service_tier` parameter is specified in the request.
                     type: string
-                    enum: ["scale", "default"]
-                    example: "scale"
+                    enum: ["auto", "default"]
+                    example: "auto"
                     nullable: true
                 system_fingerprint:
                     type: string


### PR DESCRIPTION
Per https://platform.openai.com/docs/api-reference/chat/create#chat-create-service_tier it is "auto" or "default" not "scale" or "default"