### PR TITLE
add explicit `type: object` clauses in more places

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15552,6 +15552,7 @@ components:
             "revised_prompt": "..."
           }
     ImagesResponse:
+      type: object
       properties:
         created:
           type: integer
@@ -15858,6 +15859,7 @@ components:
         - object
         - data
     ListMessagesResponse:
+      type: object
       properties:
         object:
           type: string
@@ -15913,6 +15915,7 @@ components:
         - data
         - has_more
     ListRunStepsResponse:
+      type: object
       properties:
         object:
           type: string
@@ -15962,6 +15965,7 @@ components:
         - last_id
         - has_more
     ListThreadsResponse:
+      type: object
       properties:
         object:
           type: string
@@ -15986,6 +15990,7 @@ components:
         - last_id
         - has_more
     ListVectorStoreFilesResponse:
+      type: object
       properties:
         object:
           type: string
@@ -16010,6 +16015,7 @@ components:
         - last_id
         - has_more
     ListVectorStoresResponse:
+      type: object
       properties:
         object:
           type: string
@@ -16701,6 +16707,7 @@ components:
     Model:
       title: Model
       description: Describes an OpenAI model offering that can be used with the API.
+      type: object
       properties:
         id:
           type: string
@@ -16925,6 +16932,7 @@ components:
     OpenAIFile:
       title: OpenAIFile
       description: The `File` object represents a document that has been uploaded to OpenAI.
+      type: object
       properties:
         id:
           type: string


### PR DESCRIPTION
Since some code generation tools require that.