### PR TITLE
Extract realtime API section from openapi.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,17 @@ This repository contains an [OpenAPI](https://www.openapis.org/) specification f
 ## Public mirror - do not send pull requests
 
 This is a public mirror of the internal OpenAI REST API specification. Pull requests to this spec document will not be merged. In the future, we may enable contributions and corrections via contribution to the spec, but for now they cannot be accepted. Thank you!
+
+## Realtime API
+
+The Realtime API allows you to receive real-time updates and notifications from the OpenAI platform. This can be useful for applications that need to respond to events as they happen.
+
+### Overview
+
+The Realtime API provides endpoints to subscribe to various events and receive updates in real-time. You can use this API to build applications that react to changes in the OpenAI platform as they occur.
+
+### Usage
+
+To use the Realtime API, you need to subscribe to the events you are interested in. The API will then send updates to your application as the events occur.
+
+For more details on the Realtime API, including endpoints, request parameters, and response schemas, please refer to the [realtime-api.yaml](realtime-api.yaml) file.

--- a/realtime-api.yaml
+++ b/realtime-api.yaml
@@ -1,0 +1,24 @@
+openapi: 3.0.0
+info:
+  title: OpenAI Realtime API
+  description: This is the OpenAI Realtime API specification.
+  version: 1.0.0
+paths:
+  /realtime:
+    get:
+      summary: Get real-time updates
+      description: Retrieve real-time updates from the OpenAI platform.
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  event:
+                    type: string
+                    description: The event type
+                  data:
+                    type: object
+                    description: The event data


### PR DESCRIPTION
Add a section on the Realtime API to the repository.

* **README.md**
  - Add a section mentioning the new `realtime-api.yaml` file.
  - Provide an overview and usage instructions for the Realtime API.

* **realtime-api.yaml**
  - Create a new file with the extracted section on the Realtime API from `openapi.yaml`.
  - Include the OpenAPI specification for the Realtime API, detailing the `/realtime` endpoint and its responses.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/openai/openai-openapi/pull/387?shareId=17a6cb25-dd36-497a-9b7d-359abed788c7).