### PR TITLE
fix: add missing role (`developer`) in `ChatCompletionRole`

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -13219,6 +13219,7 @@ components:
       type: string
       description: The role of the author of a message
       enum:
+        - developer
         - system
         - user
         - assistant


### PR DESCRIPTION
The `developer` message role was added recently but it was not updated in the `ChatCompletionRole` definition.