### PR TITLE
docs: clarify OpenAPI contribution workflow SDK-267

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+<!--
+For endpoint, schema, or response-header corrections, follow README.md#contributing.
+openapi.yaml and openapi.json are generated from upstream source; direct edits here
+do not update that source. OpenAI contributors should use the linked internal guide.
+Contributors without upstream access should report the correction through the
+README's feedback process. README and asset changes can be submitted here.
+-->
+
+## Summary
+
+Describe the change and why it is needed.
+
+## Validation
+
+Describe the checks performed and any affected links or rendered content reviewed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Repository guidance
+
+Read the [contribution workflow](README.md#contributing) before making changes.
+
+- `openapi.yaml` and `openapi.json` are generated publication artifacts. For endpoint, schema, parameter, or response-header changes, use the upstream authoring guide linked from the README and follow the source repository's instructions. Do not directly author a spec correction in these generated files.
+- If the upstream source is inaccessible, prepare an issue through the README's feedback process with the endpoint/method or schema, expected behavior, and a minimal example. Do not invent an internal source path or claim the correction has been applied.
+- Edit this repository's README and assets here when the request concerns those files.
+- For documentation changes, run `git diff --check`, check affected links and Markdown, and confirm that generated spec files are unchanged. This repository has no local build or test commands.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
 
 This repository publishes the OpenAPI specification for the OpenAI API. The spec describes the API's endpoints, authentication, parameters, and request and response schemas.
 
+`openapi.yaml` and `openapi.json` are generated artifacts synchronized automatically from upstream source. For specification corrections, follow the [contribution workflow](#contributing).
+
 Use it to generate typed clients, build API explorers, configure testing tools, or work with the OpenAI API in any OpenAPI-compatible workflow.
 
 > [!NOTE]
@@ -28,10 +30,10 @@ Use it to generate typed clients, build API explorers, configure testing tools, 
 
 ## Get the specification
 
-Browse [`openapi.yaml`](./openapi.yaml) directly, or download the latest version:
+Browse [`openapi.yaml`](./openapi.yaml) or [`openapi.json`](./openapi.json) directly, or download the latest YAML version:
 
 ```sh
-curl -L https://raw.githubusercontent.com/openai/openai-openapi/master/openapi.yaml \
+curl -L https://raw.githubusercontent.com/openai/openai-openapi/main/openapi.yaml \
   -o openai-openapi.yaml
 ```
 
@@ -50,11 +52,21 @@ OpenAI publishes the following official SDKs generated from this specification:
 | Java | [`openai-java`](https://github.com/openai/openai-java) |
 | Ruby | [`openai-ruby`](https://github.com/openai/openai-ruby) |
 
+## Contributing
+
+Make specification changes in the upstream source so they persist through the next publication. Direct edits to this repository's generated YAML or JSON do not update that source.
+
+**OpenAI contributors with monorepo access:** Follow the [internal OpenAPI authoring guide](https://github.com/openai/openai/blob/master/lib/js/oai_js_apidocs_data/src/openapi/README.md) and its package guidance to locate the editable definition, generate the specification, and validate the change. The publication workflow updates this repository's spec files automatically.
+
+**Contributors without monorepo access:** Use the [feedback process below](#feedback). Include proposed wording or a schema snippet in the issue when helpful so maintainers can apply the correction upstream.
+
+Changes to this README and repository assets can be submitted as pull requests here.
+
 ## Feedback
 
 Found an incorrect schema, a missing field, or another problem with the specification? [Search the existing issues](https://github.com/openai/openai-openapi/issues) and, if it has not already been reported, [open a new issue](https://github.com/openai/openai-openapi/issues/new).
 
-When reporting a problem, include the affected endpoint or schema and a minimal example when possible. The OpenAI team will make a best-effort attempt to triage and resolve spec issues.
+When reporting a problem, include the affected endpoint and HTTP method or schema, the expected behavior, and a minimal example when possible. The OpenAI team will make a best-effort attempt to triage and resolve spec issues.
 
 For immediate help with the OpenAI API, [contact OpenAI Support](https://help.openai.com/en/articles/6614161-how-can-i-contact-support).
 


### PR DESCRIPTION
## Summary

Specification corrections are currently easy to direct at the published YAML and JSON. Explain that those files are generated from upstream source, link OpenAI contributors to the authoring guide, and retain the issue-reporting route for contributors without upstream access.

Add concise agent guidance and a PR template, preserve README and asset contributions here, and correct the download URL to use `main`. The specification artifacts are unchanged.

## Validation

- `git diff --check` and staged diff checks passed.
- Checked local Markdown links/anchors and verified the upstream guide and both spec files through the GitHub API.
- Confirmed both spec file hashes match the base revision.
- Compared a fresh-context baseline with two post-change routing exercises: the internal contribution route is now discoverable; external issue reports and local README edits retain their correct destinations.
- Independent review found no actionable issues in the repository changes.
